### PR TITLE
refactor(entity): renamed entity component to parent

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,7 +17,7 @@ import Position from './position';
 import Rotation from './rotation';
 import Scale from './scale';
 import Action from './action';
-import Entity from './entity';
+import Parent from './parent';
 
 export {
   BabylonCore,
@@ -39,7 +39,7 @@ export {
   Rotation,
   Scale,
   Action,
-  Entity,
+  Parent,
 };
 
 export default [

--- a/src/components/parent.ts
+++ b/src/components/parent.ts
@@ -1,12 +1,12 @@
 import { Component, createComponentClass, Entity } from 'ecsy';
 
 interface EntityComponent extends Component {
-  parent: Entity | null;
+  value: Entity | null;
 }
 
 export default createComponentClass<EntityComponent>(
   {
-    parent: { default: null },
+    value: { default: null },
   },
-  'Entity'
+  'Parent'
 );

--- a/src/systems/material.ts
+++ b/src/systems/material.ts
@@ -1,12 +1,5 @@
 import { ComponentConstructor, Entity } from 'ecsy';
-import {
-  Mesh,
-  PBRMaterial,
-  Material,
-  ShadowOnlyMaterial,
-  BackgroundMaterial,
-  Entity as EntityComponent,
-} from '../components';
+import { Mesh, PBRMaterial, Material, ShadowOnlyMaterial, BackgroundMaterial } from '../components';
 import {
   Mesh as BabylonMesh,
   Material as BabylonMaterial,
@@ -129,13 +122,6 @@ export default class MaterialSystem extends SystemWithCore {
 
 MaterialSystem.queries = {
   ...queries,
-  entity: {
-    components: [EntityComponent],
-    listen: {
-      added: true,
-      removed: true,
-    },
-  },
   Material: {
     components: [Mesh, Material],
     listen: {

--- a/src/systems/transform.ts
+++ b/src/systems/transform.ts
@@ -1,12 +1,12 @@
 import { Entity, System } from 'ecsy';
-import { Position, Rotation, Scale, TransformNode, Entity as EntityComponent } from '../components';
+import { Position, Rotation, Scale, TransformNode, Parent } from '../components';
 import { TransformNode as BabylonTransformNode, Vector3 } from '@babylonjs/core';
 import guidFor from '../utils/guid';
 import assert from '../utils/assert';
 
 export default class TransformSystem extends System {
   execute() {
-    this.queries.entity.added.forEach((e: Entity) => this.setup(e));
+    this.queries.parent.added.forEach((e: Entity) => this.setup(e));
     this.queries.transformNode.added.forEach((e: Entity) => this.setupTransformNode(e));
 
     this.queries.position.added.forEach((e: Entity) => this.position(e));
@@ -20,7 +20,7 @@ export default class TransformSystem extends System {
     this.queries.scale.removed.forEach((e: Entity) => this.removeScale(e));
 
     // entity might remove TransformNode, so it needs to run before
-    this.queries.entity.removed.forEach((e: Entity) => this.remove(e));
+    this.queries.parent.removed.forEach((e: Entity) => this.remove(e));
     this.queries.transformNode.removed.forEach((e: Entity) => this.removeTransformNode(e));
   }
 
@@ -55,9 +55,9 @@ export default class TransformSystem extends System {
   }
 
   setupTransformNode(entity: Entity) {
-    const entityComponent = entity.getComponent(EntityComponent);
+    const entityComponent = entity.getComponent(Parent);
     const transformNodeComponent = entity.getComponent(TransformNode);
-    const parentEntity = entityComponent.parent;
+    const parentEntity = entityComponent.value;
 
     if (transformNodeComponent.value) {
       if (transformNodeComponent.clone) {
@@ -138,8 +138,8 @@ export default class TransformSystem extends System {
 }
 
 TransformSystem.queries = {
-  entity: {
-    components: [EntityComponent],
+  parent: {
+    components: [Parent],
     listen: {
       added: true,
       removed: true,


### PR DESCRIPTION
the name was confusing, caused name conflicts with the real Entity. Also aligns with
https://github.com/MozillaReality/ecsy-three/blob/master/src/components/Parent.js

BREAKING CHANGE: changed named export, use `value` as component property