### PR TITLE
fix(exports): export all modules/types from index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     }
   },
   "dependencies": {
-    "@babylonjs/core": "^4.1.0-beta.20",
+    "@babylonjs/core": "^4.1.0-beta.22",
     "@babylonjs/inspector": "^4.1.0-beta.22",
-    "@babylonjs/loaders": "^4.1.0-beta.20",
+    "@babylonjs/loaders": "^4.1.0-beta.22",
     "@babylonjs/materials": "^4.1.0-beta.22",
     "ecsy": "^0.2.1"
   },

--- a/src/components/parent.ts
+++ b/src/components/parent.ts
@@ -1,10 +1,10 @@
 import { Component, createComponentClass, Entity } from 'ecsy';
 
-interface EntityComponent extends Component {
+export interface ParentComponent extends Component {
   value: Entity | null;
 }
 
-export default createComponentClass<EntityComponent>(
+export default createComponentClass<ParentComponent>(
   {
     value: { default: null },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
 export { default as components } from './components';
 export { default as systems } from './systems';
+
+export * from './components';
+export * from './systems';

--- a/src/systems/index.ts
+++ b/src/systems/index.ts
@@ -1,21 +1,33 @@
-import Babylon from './babylon';
-import Camera from './camera';
-import Transform from './transform';
-import Primitive from './primitive';
-import Mesh from './mesh';
-import Material from './material';
-import Light from './light';
-import Shadow from './shadow';
-import Action from './action';
+import BabylonSystem from './babylon';
+import CameraSystem from './camera';
+import TransformSystem from './transform';
+import PrimitiveSystem from './primitive';
+import MeshSystem from './mesh';
+import MaterialSystem from './material';
+import LightSystem from './light';
+import ShadowSystem from './shadow';
+import ActionSystem from './action';
 
-export { default as Babylon } from './babylon';
-export { default as Camera } from './camera';
-export { default as Transform } from './transform';
-export { default as Primitive } from './primitive';
-export { default as Mesh } from './mesh';
-export { default as Material } from './material';
-export { default as Light } from './light';
-export { default as Shadow } from './shadow';
-export { default as Action } from './action';
+export {
+  BabylonSystem,
+  TransformSystem,
+  CameraSystem,
+  PrimitiveSystem,
+  MeshSystem,
+  MaterialSystem,
+  LightSystem,
+  ShadowSystem,
+  ActionSystem,
+};
 
-export default [Babylon, Transform, Camera, Primitive, Mesh, Material, Light, Shadow, Action];
+export default [
+  BabylonSystem,
+  TransformSystem,
+  CameraSystem,
+  PrimitiveSystem,
+  MeshSystem,
+  MaterialSystem,
+  LightSystem,
+  ShadowSystem,
+  ActionSystem,
+];

--- a/test/babylon.test.ts
+++ b/test/babylon.test.ts
@@ -1,5 +1,5 @@
 import { World } from 'ecsy';
-import { Babylon } from '../src/systems';
+import { BabylonSystem } from '../src/systems';
 import { BabylonCore } from '../src/components';
 import { NullEngine } from '@babylonjs/core';
 import { waitForRAF } from './helpers/wait';
@@ -8,7 +8,7 @@ describe('babylon system', function() {
   it('sets up babylon scene', function() {
     const canvas = document.createElement('canvas');
     const world = new World();
-    world.registerSystem(Babylon);
+    world.registerSystem(BabylonSystem);
 
     const entity = world.createEntity();
 
@@ -28,7 +28,7 @@ describe('babylon system', function() {
   it('calls render beforeRender and afterRender', async function() {
     const canvas = document.createElement('canvas');
     const world = new World();
-    world.registerSystem(Babylon);
+    world.registerSystem(BabylonSystem);
 
     const entity = world.createEntity();
     const beforeRender = jest.fn();

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "include": [
-    "src"
+    "src",
+    "types/**/*"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,7 +722,7 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babylonjs/core@4.1.0-beta.22", "@babylonjs/core@^4.1.0-beta.20":
+"@babylonjs/core@4.1.0-beta.22", "@babylonjs/core@^4.1.0-beta.22":
   version "4.1.0-beta.22"
   resolved "https://registry.yarnpkg.com/@babylonjs/core/-/core-4.1.0-beta.22.tgz#5498fcb72ad3ee5f7d186d19524f27860229f2a1"
   integrity sha512-QRuunJLvrvu2mAk+XjQ0tApL3+tcdWth7ev7uaQ3roUG6SKRGgjdUbLxuPhKMzaOEW4HoRTD2ewk5hEAA1yWvQ==
@@ -750,7 +750,7 @@
     babylonjs-gltf2interface "4.1.0-beta.22"
     tslib "^1.10.0"
 
-"@babylonjs/loaders@4.1.0-beta.22", "@babylonjs/loaders@^4.1.0-beta.20":
+"@babylonjs/loaders@4.1.0-beta.22", "@babylonjs/loaders@^4.1.0-beta.22":
   version "4.1.0-beta.22"
   resolved "https://registry.yarnpkg.com/@babylonjs/loaders/-/loaders-4.1.0-beta.22.tgz#451007a85db0002c6a5ded7cd71f47e906e6d6ab"
   integrity sha512-JVhCkI44Z2XLcuMRsvi1xBJ6BRKd2o6UtbcGqRdZbMwtHNk+/U64z9LCCBb/DzVdKPLR+RvVLm5rIruSWz7Khw==


### PR DESCRIPTION
the UMD/CJS builds are bundled into a single file, so e.g. `ecsy-babylon/components` does not exist for them. Also TS was not able to find the child modules typings somehow. :/

BREAKING CHANGE: refactored module exports