### PR TITLE
build: fix build failing due to TS errors

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,8 @@ export default [
       include: 'src/**',
     },
     plugins: [
-      typescript(),
+      // @todo remove `noEmitOnError` when the typescript plugin has been fixed in v4, see https://github.com/rollup/plugins/pull/217
+      typescript({ tsconfig: 'tsconfig.build.json', noEmitOnError: false }),
       // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
       commonjs(),
       resolve(),
@@ -28,6 +29,7 @@ export default [
     watch: {
       include: 'src/**',
     },
-    plugins: [typescript(), sourceMaps()],
+    // @todo remove `noEmitOnError` when the typescript plugin has been fixed in v4, see https://github.com/rollup/plugins/pull/217
+    plugins: [typescript({ tsconfig: 'tsconfig.build.json', noEmitOnError: false }), sourceMaps()],
   },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -9513,9 +9513,9 @@ typescript@3.7.x:
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 typescript@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
-  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.7.5"


### PR DESCRIPTION
the errors itself are not present when working directly with TS (e.g. `yarn lint:ts`). Seems to be a bug in the rollup plugin, which is hopefully fixed with the next release (https://github.com/rollup/plugins/pull/217)