### PR TITLE
chore: don't expose UMD build as `browser` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "",
   "keywords": [],
-  "browser": "dist/index.umd.js",
   "main": "dist/index.cjs.js",
   "module": "dist/src/index.js",
   "typings": "dist/types/index.d.ts",


### PR DESCRIPTION
The field is used by default by webpack / ember-auto-import, but UMD is the worst choice for modern build system, as it is not tree-shakable and includes all dependencies including babylon.js. Removing it from package.json, but keeping the build in the `dist` folder for explicit use