### PR TITLE
fix(pbr-material): fix name for uglified builds

### DIFF
--- a/src/components/material.ts
+++ b/src/components/material.ts
@@ -2,6 +2,7 @@ import { Component, createComponentClass } from 'ecsy';
 import { Material } from '@babylonjs/core';
 
 export interface MaterialComponent extends Component {
+  name: string;
   value: Material | null;
   sideOrientation?: number;
   useObjectSpaceNormalMap?: boolean;

--- a/src/components/pbr-material.ts
+++ b/src/components/pbr-material.ts
@@ -1,11 +1,7 @@
 import { Component } from 'ecsy';
 import { BaseTexture, Color3, PBRMaterial as BabylonPBRMaterial } from '@babylonjs/core';
 
-const DEFAULT_NAME = 'PbrMaterial';
-
 export default class PbrMaterial extends Component {
-  name = DEFAULT_NAME;
-
   directIntensity = 1;
   emissiveIntensity = 1;
   environmentIntensity = 1;
@@ -65,7 +61,6 @@ export default class PbrMaterial extends Component {
   unlit = false;
 
   reset(): void {
-    this.name = DEFAULT_NAME;
     this.directIntensity = 1;
     this.emissiveIntensity = 1;
     this.environmentIntensity = 1;
@@ -125,3 +120,5 @@ export default class PbrMaterial extends Component {
     this.unlit = false;
   }
 }
+
+Object.defineProperty(PbrMaterial, 'name', { value: 'PbrMaterial' });

--- a/src/systems/material.ts
+++ b/src/systems/material.ts
@@ -111,6 +111,8 @@ export default class MaterialSystem extends SystemWithCore {
   ): void {
     assert('MaterialSystem needs BabylonCoreComponent', this.core);
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
     const { name, ...props } = entity.getComponent(Component);
 
     const material = new MaterialClass(name, this.core.scene);


### PR DESCRIPTION
In a production build with uglification enabled, the (newly refactored as a native class) PbrMaterial was not found. The reason was that after uglification, the name of the class was actually (in this case) `t`, so its `name` was accordingly `'t'`. Which results in our Ember "component component" not being able to look the component up.

This also revealed that our use of `name` was ambiguous, as we allowed passing a name as an argument for setting this as the (custom) name of some Babylon.js instance (e.g. material name), but this would override the name used for looking up the component.

The way `name` is used inside of ecsy's ComponentManager is by using the name of the constructor function basically, which is automatically set, but which is also going to change when uglified.

This here is a quick fix, enforcing a fixed name for the native class component, similar to what CreateComponentClass does: https://github.com/MozillaReality/ecsy/blob/dev/src/CreateComponentClass.js#L25, and also removing passing name as an argument. But I believe the long term goal should be to *not* use ComponentManager to lookup ecsy components (https://github.com/kaliber5/ember-ecsy-babylon/blob/master/addon/components/ecsy/component.ts#L34), as it's private anyway, and the use of its `Components` hash is unclear, see https://github.com/MozillaReality/ecsy/issues/147. Rather we should pass a hash of name, component pairs (instead of an array here https://github.com/kaliber5/ember-ecsy-babylon/blob/master/addon/components/ecsy.ts#L27) and use our own "registry" for component lookup IMO, that provides an explicit mapping, instead of relying on the component constructor's name.