### PR TITLE
Allow overrides of material

### DIFF
--- a/src/components/material.ts
+++ b/src/components/material.ts
@@ -3,9 +3,11 @@ import { Material as BabylonMaterial } from '@babylonjs/core/Materials/material'
 
 export default class Material extends Component {
   value: BabylonMaterial | null = null;
+  overrides: Record<string, unknown> = {};
 
   reset(): void {
     this.value = null;
+    this.overrides = {};
   }
 }
 

--- a/src/systems/material.ts
+++ b/src/systems/material.ts
@@ -70,9 +70,9 @@ export default class MaterialSystem extends SystemWithCore {
     const materialComponent = entity.getComponent(Material);
 
     if (materialComponent.value) {
-      const { value, ...restArgs } = materialComponent;
+      const { value, overrides } = materialComponent;
 
-      Object.assign(value, restArgs);
+      Object.assign(value, overrides);
       mesh.material = value;
     } else {
       console.warn(`No material was applied to mesh "${mesh.name}".`);

--- a/test/material.test.ts
+++ b/test/material.test.ts
@@ -2,32 +2,68 @@ import { BabylonCore, Box, Parent, PBRMaterial } from '../src/components';
 import { Color3 } from '@babylonjs/core/Maths/math.color';
 import { PBRMaterial as BabylonPBRMaterial } from '@babylonjs/core/Materials/PBR/pbrMaterial';
 import setupWorld from './helpers/setup-world';
+import { StandardMaterial } from '@babylonjs/core/Materials/standardMaterial';
+import Material from '../src/components/material';
 
 describe('material system', function () {
-  it('can add PBR material', function () {
-    const { world, rootEntity } = setupWorld();
+  describe('pbr material', function () {
+    it('can add PBR material', function () {
+      const { world, rootEntity } = setupWorld();
 
-    const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Box).addComponent(PBRMaterial, { name: 'test' });
+      const entity = world.createEntity();
+      entity.addComponent(Parent).addComponent(Box).addComponent(PBRMaterial, { name: 'test' });
 
-    world.execute(0, 0);
+      world.execute(0, 0);
 
-    const { scene } = rootEntity.getComponent(BabylonCore);
-    const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
+      const { scene } = rootEntity.getComponent(BabylonCore);
+      const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
 
-    expect(material).toBeInstanceOf(BabylonPBRMaterial);
-    expect(material.albedoColor.equalsFloats(1, 1, 1)).toBeTrue();
-  });
+      expect(material).toBeInstanceOf(BabylonPBRMaterial);
+      expect(scene.meshes[0].material).toEqual(material);
+      expect(material.albedoColor.equalsFloats(1, 1, 1)).toBeTrue();
+    });
 
-  it('can add PBR material with custom values', function () {
-    const { world, rootEntity } = setupWorld();
+    it('can add PBR material with custom values', function () {
+      const { world, rootEntity } = setupWorld();
 
-    const entity = world.createEntity();
-    entity
-      .addComponent(Parent)
-      .addComponent(Box)
-      .addComponent(PBRMaterial, {
-        name: 'test',
+      const entity = world.createEntity();
+      entity
+        .addComponent(Parent)
+        .addComponent(Box)
+        .addComponent(PBRMaterial, {
+          name: 'test',
+          albedoColor: new Color3(1, 0, 0),
+          ambientColor: new Color3(0, 1, 0),
+          emissiveColor: new Color3(0, 0, 1),
+          roughness: 0.5,
+          metallic: 0.1,
+        });
+
+      world.execute(0, 0);
+
+      const { scene } = rootEntity.getComponent(BabylonCore);
+      const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
+
+      expect(material).toBeInstanceOf(BabylonPBRMaterial);
+      expect(scene.meshes[0].material).toEqual(material);
+      expect(material.albedoColor.equalsFloats(1, 0, 0)).toBeTrue();
+      expect(material.ambientColor.equalsFloats(0, 1, 0)).toBeTrue();
+      expect(material.emissiveColor.equalsFloats(0, 0, 1)).toBeTrue();
+      expect(material.roughness).toEqual(0.5);
+      expect(material.metallic).toEqual(0.1);
+    });
+
+    it('can update PBR material', function () {
+      const { world, rootEntity } = setupWorld();
+
+      const entity = world.createEntity();
+      entity.addComponent(Parent).addComponent(Box).addComponent(PBRMaterial, { name: 'test' });
+
+      world.execute(0, 0);
+
+      const { scene } = rootEntity.getComponent(BabylonCore);
+      const component = entity.getMutableComponent(PBRMaterial);
+      Object.assign(component, {
         albedoColor: new Color3(1, 0, 0),
         ambientColor: new Color3(0, 1, 0),
         emissiveColor: new Color3(0, 0, 1),
@@ -35,90 +71,122 @@ describe('material system', function () {
         metallic: 0.1,
       });
 
-    world.execute(0, 0);
+      world.execute(0, 0);
 
-    const { scene } = rootEntity.getComponent(BabylonCore);
-    const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
+      const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
 
-    expect(material).toBeInstanceOf(BabylonPBRMaterial);
-    expect(scene.meshes[0].material).toEqual(material);
-    expect(material.albedoColor.equalsFloats(1, 0, 0)).toBeTrue();
-    expect(material.ambientColor.equalsFloats(0, 1, 0)).toBeTrue();
-    expect(material.emissiveColor.equalsFloats(0, 0, 1)).toBeTrue();
-    expect(material.roughness).toEqual(0.5);
-    expect(material.metallic).toEqual(0.1);
-  });
-
-  it('can update PBR material', function () {
-    const { world, rootEntity } = setupWorld();
-
-    const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Box).addComponent(PBRMaterial, { name: 'test' });
-
-    world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore);
-    const component = entity.getMutableComponent(PBRMaterial);
-    Object.assign(component, {
-      albedoColor: new Color3(1, 0, 0),
-      ambientColor: new Color3(0, 1, 0),
-      emissiveColor: new Color3(0, 0, 1),
-      roughness: 0.5,
-      metallic: 0.1,
+      expect(material).toBeInstanceOf(BabylonPBRMaterial);
+      expect(scene.meshes[0].material).toEqual(material);
+      expect(material.albedoColor.equalsFloats(1, 0, 0)).toBeTrue();
+      expect(material.ambientColor.equalsFloats(0, 1, 0)).toBeTrue();
+      expect(material.emissiveColor.equalsFloats(0, 0, 1)).toBeTrue();
+      expect(material.roughness).toEqual(0.5);
+      expect(material.metallic).toEqual(0.1);
     });
 
-    world.execute(0, 0);
+    it('can apply PBR material to updated mesh', function () {
+      const { world, rootEntity } = setupWorld();
 
-    const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
+      const entity = world.createEntity();
+      entity
+        .addComponent(Parent)
+        .addComponent(Box)
+        .addComponent(PBRMaterial, { name: 'test', albedoColor: new Color3(1, 0, 0) });
 
-    expect(material).toBeInstanceOf(BabylonPBRMaterial);
-    expect(scene.meshes[0].material).toEqual(material);
-    expect(material.albedoColor.equalsFloats(1, 0, 0)).toBeTrue();
-    expect(material.ambientColor.equalsFloats(0, 1, 0)).toBeTrue();
-    expect(material.emissiveColor.equalsFloats(0, 0, 1)).toBeTrue();
-    expect(material.roughness).toEqual(0.5);
-    expect(material.metallic).toEqual(0.1);
+      world.execute(0, 0);
+
+      const { scene } = rootEntity.getComponent(BabylonCore);
+      const component = entity.getMutableComponent(Box);
+      component.size = 2;
+
+      world.execute(0, 0);
+
+      const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
+
+      expect(material).toBeInstanceOf(BabylonPBRMaterial);
+      expect(scene.meshes[0].material).toEqual(material);
+      expect(material.albedoColor.equalsFloats(1, 0, 0)).toBeTrue();
+    });
+
+    it('can remove PBR material', function () {
+      const { world, rootEntity } = setupWorld();
+
+      const entity = world.createEntity();
+      entity.addComponent(Parent).addComponent(Box).addComponent(PBRMaterial, { name: 'test' });
+
+      world.execute(0, 0);
+
+      const { scene } = rootEntity.getComponent(BabylonCore);
+
+      entity.remove();
+      world.execute(0, 0);
+
+      const material = scene.getMaterialByName('test');
+
+      expect(material).toBeNull();
+    });
   });
 
-  it('can apply PBR material to updated mesh', function () {
-    const { world, rootEntity } = setupWorld();
+  describe('material', function () {
+    it('can add existing material instance', function () {
+      const { world, rootEntity } = setupWorld();
 
-    const entity = world.createEntity();
-    entity
-      .addComponent(Parent)
-      .addComponent(Box)
-      .addComponent(PBRMaterial, { name: 'test', albedoColor: new Color3(1, 0, 0) });
+      world.execute(0, 0);
 
-    world.execute(0, 0);
+      const entity = world.createEntity();
+      const { scene } = rootEntity.getComponent(BabylonCore);
 
-    const { scene } = rootEntity.getComponent(BabylonCore);
-    const component = entity.getMutableComponent(Box);
-    component.size = 2;
+      const material = new StandardMaterial('test', scene);
+      entity.addComponent(Parent).addComponent(Box).addComponent(Material, { value: material });
 
-    world.execute(0, 0);
+      world.execute(0, 0);
 
-    const material = scene.getMaterialByName('test') as BabylonPBRMaterial;
+      expect(scene.meshes[0].material).toEqual(material);
+    });
 
-    expect(material).toBeInstanceOf(BabylonPBRMaterial);
-    expect(scene.meshes[0].material).toEqual(material);
-    expect(material.albedoColor.equalsFloats(1, 0, 0)).toBeTrue();
-  });
+    it('can override material properties', function () {
+      const { world, rootEntity } = setupWorld();
 
-  it('can remove PBR material', function () {
-    const { world, rootEntity } = setupWorld();
+      world.execute(0, 0);
 
-    const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Box).addComponent(PBRMaterial, { name: 'test' });
+      const entity = world.createEntity();
+      const { scene } = rootEntity.getComponent(BabylonCore);
 
-    world.execute(0, 0);
+      const material = new StandardMaterial('test', scene);
+      entity
+        .addComponent(Parent)
+        .addComponent(Box)
+        .addComponent(Material, { value: material, overrides: { useParallax: true } });
 
-    const { scene } = rootEntity.getComponent(BabylonCore);
+      world.execute(0, 0);
 
-    entity.remove();
-    world.execute(0, 0);
+      expect(scene.meshes[0].material).toEqual(material);
+      expect(material.useParallax).toBeTrue();
+    });
 
-    const material = scene.getMaterialByName('test');
+    it('can update overridden material properties', function () {
+      const { world, rootEntity } = setupWorld();
 
-    expect(material).toBeNull();
+      world.execute(0, 0);
+
+      const entity = world.createEntity();
+      const { scene } = rootEntity.getComponent(BabylonCore);
+
+      const material = new StandardMaterial('test', scene);
+      entity
+        .addComponent(Parent)
+        .addComponent(Box)
+        .addComponent(Material, { value: material, overrides: { useParallax: true } });
+
+      world.execute(0, 0);
+
+      const materialComponent = entity.getMutableComponent(Material);
+      materialComponent.overrides.useParallax = false;
+
+      world.execute(0, 0);
+
+      expect(scene.meshes[0].material).toEqual(material);
+      expect(material.useParallax).toBeFalse();
+    });
   });
 });


### PR DESCRIPTION
When given an existing Material instance to the `material` component, `overrides` allows to set properties on that instance. This was working before by just passing any properties, but caused problems with component pooling, as `reset()` did not clean those up.