### PR TITLE
Allow overrides of mesh

### DIFF
--- a/src/components/mesh.ts
+++ b/src/components/mesh.ts
@@ -3,11 +3,13 @@ import { AbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
 
 export default class MeshComponent extends Component {
   value: AbstractMesh | null = null;
+  overrides: Record<string, unknown> = {};
   _prevValue: AbstractMesh | null = null;
 
   reset(): void {
     this.value = null;
     this._prevValue = null;
+    this.overrides = {};
   }
 }
 

--- a/src/systems/mesh.ts
+++ b/src/systems/mesh.ts
@@ -36,9 +36,8 @@ export default class MeshSystem extends SystemWithCore {
     mesh.computeWorldMatrix(true); // @todo still needed?
     meshComponent.value = mesh;
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { value, _prevValue, ...restArgs } = meshComponent;
-    Object.assign(value, restArgs);
+    const { value, overrides } = meshComponent;
+    Object.assign(value, overrides);
 
     this.core.scene.addMesh(mesh);
     meshComponent._prevValue = mesh;

--- a/test/mesh.test.ts
+++ b/test/mesh.test.ts
@@ -140,4 +140,58 @@ describe('mesh system', function () {
     expect(scene.meshes).toHaveLength(0);
     expect(scene.geometries).toHaveLength(0);
   });
+
+  it('can override mesh properties', function () {
+    const { world, rootEntity } = setupWorld();
+
+    // wait for scene to be created before creating meshes
+    world.execute(0, 0);
+
+    const entity = world.createEntity();
+    entity
+      .addComponent(Parent)
+      .addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }), overrides: { isVisible: false } });
+
+    world.execute(0, 0);
+
+    const { scene } = rootEntity.getComponent(BabylonCore);
+
+    expect(scene.meshes).toHaveLength(1);
+    expect(scene.geometries).toHaveLength(1);
+
+    const mesh = scene.meshes[0];
+    expect(mesh).toBeInstanceOf(BabylonMesh);
+    expect(mesh.name).toMatch(/test/);
+    expect(mesh.isVisible).toBeFalse();
+  });
+
+  it('can update overridden mesh properties', function () {
+    const { world, rootEntity } = setupWorld();
+
+    // wait for scene to be created before creating meshes
+    world.execute(0, 0);
+
+    const entity = world.createEntity();
+    entity
+      .addComponent(Parent)
+      .addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }), overrides: { isVisible: false } });
+
+    world.execute(0, 0);
+
+    const { scene } = rootEntity.getComponent(BabylonCore);
+
+    expect(scene.meshes).toHaveLength(1);
+    expect(scene.geometries).toHaveLength(1);
+
+    const meshComponent = entity.getMutableComponent(Mesh);
+    expect(meshComponent).toBeDefined();
+    meshComponent.overrides.isVisible = true;
+
+    world.execute(0, 0);
+
+    const mesh = scene.meshes[0];
+    expect(mesh).toBeInstanceOf(BabylonMesh);
+    expect(mesh.name).toMatch(/test/);
+    expect(mesh.isVisible).toBeTrue();
+  });
 });


### PR DESCRIPTION
When given an existing Mesh instance to the `mesh` component, `overrides` allows to set properties on that instance. This was working before by just passing any properties, but caused problems with component pooling, as `reset()` did not clean those up.