### PR TITLE
Use custom assign helper to ignore undefined values

### DIFF
--- a/src/-private/utils/assign.ts
+++ b/src/-private/utils/assign.ts
@@ -1,0 +1,16 @@
+/**
+ * Assign properties of a component to target. Similar to Object.assign, but ignores undefined values
+ * @param target
+ * @param source
+ */
+import { Component } from 'ecsy';
+
+export default function assign<T extends object>(target: T, source: Partial<T> | Component<Partial<T>>): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore
+      target[key] = value;
+    }
+  }
+}

--- a/src/components/arc-rotate-camera.ts
+++ b/src/components/arc-rotate-camera.ts
@@ -11,11 +11,11 @@ export default class ArcRotateCamera extends Component<ArcRotateCamera> {
   target!: Vector3;
 
   lowerAlphaLimit!: number | null;
-  lowerBetaLimit!: number | null;
+  lowerBetaLimit?: number;
   lowerRadiusLimit!: number | null;
 
   upperAlphaLimit!: number | null;
-  upperBetaLimit!: number | null;
+  upperBetaLimit?: number;
   upperRadiusLimit!: number | null;
 
   static schema: ComponentSchema = {
@@ -25,10 +25,10 @@ export default class ArcRotateCamera extends Component<ArcRotateCamera> {
     radius: { type: Types.Number, default: 10 },
     target: { type: BabylonTypes.Vector3 },
     lowerAlphaLimit: { type: Types.Number, default: null },
-    lowerBetaLimit: { type: Types.Number, default: null },
+    lowerBetaLimit: { type: Types.Number, default: undefined },
     lowerRadiusLimit: { type: Types.Number, default: null },
     upperAlphaLimit: { type: Types.Number, default: null },
-    upperBetaLimit: { type: Types.Number, default: null },
+    upperBetaLimit: { type: Types.Number, default: undefined },
     upperRadiusLimit: { type: Types.Number, default: null },
   };
 }

--- a/src/components/shadow-generator.ts
+++ b/src/components/shadow-generator.ts
@@ -6,7 +6,7 @@ export default class ShadowGenerator extends Component<ShadowGenerator> {
   size = 512;
   enableSoftTransparentShadow?: boolean;
   forceBackFacesOnly?: boolean;
-  frustumEdgeFalloff?: boolean;
+  frustumEdgeFalloff?: number;
   useBlurCloseExponentialShadowMap?: boolean;
   useBlurExponentialShadowMap?: boolean;
   useCloseExponentialShadowMap?: boolean;

--- a/src/systems/camera.ts
+++ b/src/systems/camera.ts
@@ -3,6 +3,7 @@ import { ArcRotateCamera, TransformNode } from '../components';
 import { ArcRotateCamera as BabylonArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
 import SystemWithCore, { queries } from '../-private/SystemWithCore';
 import assert from '../-private/utils/assert';
+import assign from '../-private/utils/assign';
 
 export default class CameraSystem extends SystemWithCore {
   execute(): void {
@@ -25,7 +26,7 @@ export default class CameraSystem extends SystemWithCore {
     const instance =
       value || new BabylonArcRotateCamera(ArcRotateCamera.name, alpha, beta, radius, target, scene, false);
 
-    Object.assign(instance, args);
+    assign(instance, args);
     cameraComponent.value = instance;
 
     scene.activeCamera = instance;
@@ -38,10 +39,10 @@ export default class CameraSystem extends SystemWithCore {
 
   update(entity: Entity, component: ComponentConstructor<ArcRotateCamera>): void {
     const cameraComponent = entity.getComponent(component)!;
-
     const { value, ...args } = cameraComponent;
+    assert('No camera instance found', value);
 
-    Object.assign(value, args);
+    assign(value, args);
   }
 
   remove(entity: Entity, component: ComponentConstructor<ArcRotateCamera>): void {

--- a/src/systems/light.ts
+++ b/src/systems/light.ts
@@ -7,6 +7,7 @@ import { Light as _Light } from '@babylonjs/core/Lights/light';
 import { Scene } from '@babylonjs/core/scene';
 import Light from '../components/_light';
 import assert from '../-private/utils/assert';
+import assign from '../-private/utils/assign';
 
 export default class LightSystem extends System {
   execute(): void {
@@ -34,7 +35,7 @@ export default class LightSystem extends System {
       (null as unknown) as Scene // passing null is actually possible, but the typings require a Scene
     );
 
-    Object.assign(component._light, options);
+    assign(component._light, options);
 
     const transformNodeComponent = entity.getComponent(TransformNode);
     assert('TransformNode needed for lights, add Parent component to fix', transformNodeComponent);
@@ -53,7 +54,7 @@ export default class LightSystem extends System {
       (null as unknown) as Scene // passing null is actually possible, but the typings require a Scene
     );
 
-    Object.assign(component._light, options);
+    assign(component._light, options);
 
     const transformNodeComponent = entity.getComponent(TransformNode);
     assert('TransformNode needed for lights, add Parent component to fix', transformNodeComponent);
@@ -72,7 +73,7 @@ export default class LightSystem extends System {
       (null as unknown) as Scene // passing null is actually possible, but the typings require a Scene
     );
 
-    Object.assign(component._light, options);
+    assign(component._light, options);
 
     const transformNodeComponent = entity.getComponent(TransformNode);
     assert('TransformNode needed for lights, add Parent component to fix', transformNodeComponent);
@@ -83,10 +84,10 @@ export default class LightSystem extends System {
   update<L extends Light<L, _Light>>(entity: Entity, Component: ComponentConstructor<L>): void {
     const component = entity.getComponent(Component)!;
     const { _light, ...rest } = component;
+    assert('No light instance found', _light);
 
-    if (_light) {
-      Object.assign(_light, rest);
-    }
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    assign(_light as _Light, rest);
   }
 
   remove<L extends Light<L, _Light>>(entity: Entity, Component: ComponentConstructor<L>): void {

--- a/src/systems/material.ts
+++ b/src/systems/material.ts
@@ -7,6 +7,7 @@ import { StandardMaterial as BabylonStandardMaterial } from '@babylonjs/core/Mat
 import { Scene } from '@babylonjs/core/scene';
 import { ShadowOnlyMaterial as BabylonShadowOnlyMaterial } from '@babylonjs/materials/shadowOnly/shadowOnlyMaterial';
 import assert from '../-private/utils/assert';
+import assign from '../-private/utils/assign';
 import SystemWithCore, { queries } from '../-private/SystemWithCore';
 import { AbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
 
@@ -72,7 +73,7 @@ export default class MaterialSystem extends SystemWithCore {
     if (materialComponent.value) {
       const { value, overrides } = materialComponent;
 
-      Object.assign(value, overrides);
+      assign(value, overrides);
       mesh.material = value;
     } else {
       console.warn(`No material was applied to mesh "${mesh.name}".`);
@@ -100,7 +101,8 @@ export default class MaterialSystem extends SystemWithCore {
     const props = entity.getComponent(Component);
 
     const material = new MaterialClass(Component.name, this.core.scene);
-    Object.assign(material, props);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    assign(material, props!);
 
     entity.addComponent(Material, { value: material });
   }
@@ -112,7 +114,10 @@ export default class MaterialSystem extends SystemWithCore {
     const mesh = this.getMesh(entity);
     const materialComponent = entity.getComponent(Component);
 
-    Object.assign(mesh.material, materialComponent);
+    if (mesh.material) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      assign(mesh.material, materialComponent!);
+    }
   }
 
   removeMaterial(entity: Entity): void {

--- a/src/systems/mesh.ts
+++ b/src/systems/mesh.ts
@@ -2,6 +2,7 @@ import { Entity } from 'ecsy';
 import { Mesh, TransformNode, Material } from '../components';
 import SystemWithCore, { queries } from '../-private/SystemWithCore';
 import assert from '../-private/utils/assert';
+import assign from '../-private/utils/assign';
 import { AbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
 
 function detachFromScene(mesh: AbstractMesh): void {
@@ -39,7 +40,7 @@ export default class MeshSystem extends SystemWithCore {
     meshComponent.value = mesh;
 
     const { value, overrides } = meshComponent;
-    Object.assign(value, overrides);
+    assign(value, overrides);
 
     this.core.scene.addMesh(mesh);
     meshComponent._prevValue = mesh;

--- a/src/systems/shadow.ts
+++ b/src/systems/shadow.ts
@@ -5,6 +5,7 @@ import assert from '../-private/utils/assert';
 import { InstancedMesh } from '@babylonjs/core/Meshes/instancedMesh';
 import { ShadowGenerator as _ShadowGenerator } from '@babylonjs/core/Lights/Shadows/shadowGenerator';
 import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent';
+import assign from '../-private/utils/assign';
 
 export default class ShadowSystem extends SystemWithCore {
   execute(): void {
@@ -42,7 +43,7 @@ export default class ShadowSystem extends SystemWithCore {
     const { value, ...options } = component;
 
     const shadowGenerator = new _ShadowGenerator(options.size, light);
-    Object.assign(shadowGenerator, options);
+    assign(shadowGenerator, options);
 
     // disable continuous shadow calculation
     // light.autoUpdateExtends = false;
@@ -69,7 +70,7 @@ export default class ShadowSystem extends SystemWithCore {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { value, ...options } = shadowComponent;
 
-    Object.assign(shadowComponent.value, options);
+    assign(shadowComponent.value, options);
   }
 
   addMesh(entity: Entity): void {

--- a/test/camera.test.ts
+++ b/test/camera.test.ts
@@ -33,10 +33,10 @@ describe('camera system', function () {
     expect(camera.beta).toEqual(0);
     expect(camera.radius).toEqual(10);
     expect(camera.lowerAlphaLimit).toBeNull();
-    expect(camera.lowerBetaLimit).toBeNull();
+    expect(camera.lowerBetaLimit).toBeGreaterThan(0); // has a default value!
     expect(camera.lowerRadiusLimit).toBeNull();
     expect(camera.upperAlphaLimit).toBeNull();
-    expect(camera.upperBetaLimit).toBeNull();
+    expect(camera.upperBetaLimit).toBeGreaterThan(0); // has a default value!
     expect(camera.upperRadiusLimit).toBeNull();
   });
 

--- a/test/shadow.test.ts
+++ b/test/shadow.test.ts
@@ -24,6 +24,8 @@ describe('shadow system', function () {
     const shadowGenerator = (light.getShadowGenerator() as unknown) as ShadowGenerator;
     expect(shadowGenerator).toBeDefined();
     expect(shadowGenerator.size).toEqual(512);
+    expect(shadowGenerator.forceBackFacesOnly).toBeFalse();
+    expect(shadowGenerator.darkness).toEqual(0); // make sure default values are preserved
   });
 
   it('can add shadow generator with custom arguments', function () {
@@ -50,6 +52,7 @@ describe('shadow system', function () {
     const shadowGenerator = (light.getShadowGenerator() as unknown) as ShadowGenerator;
     expect(shadowGenerator.size).toEqual(1024);
     expect(shadowGenerator.forceBackFacesOnly).toBeTrue();
+    expect(shadowGenerator.darkness).toEqual(0); // make sure default values are preserved
   });
 
   it('can update shadow generator', function () {
@@ -76,6 +79,7 @@ describe('shadow system', function () {
     const shadowGenerator = (light.getShadowGenerator() as unknown) as ShadowGenerator;
     expect(shadowGenerator.size).toEqual(1024);
     expect(shadowGenerator.forceBackFacesOnly).toBeTrue();
+    expect(shadowGenerator.darkness).toEqual(0); // make sure default values are preserved
   });
 
   it('can remove shadow generator', function () {


### PR DESCRIPTION
Previously through the use of `Object.assign` undefined values in a component could override default values of a Babylon instance. The new helper will ignore undefined values, and provide some better type safety.