### PR TITLE
Introduce InstanceComponent

### DIFF
--- a/src/components/_instance.ts
+++ b/src/components/_instance.ts
@@ -1,0 +1,25 @@
+import { Component, ComponentSchema, Types } from 'ecsy';
+
+export default abstract class InstanceComponent<C, I> extends Component<C> {
+  overrides!: Record<string, unknown>;
+  private _value?: I;
+  private _previousValue?: I;
+
+  get value(): I | undefined {
+    return this._value;
+  }
+
+  set value(value: I | undefined) {
+    this._previousValue = this._value;
+    this._value = value;
+  }
+
+  get previousValue(): I | undefined {
+    return this._previousValue;
+  }
+
+  static schema: ComponentSchema = {
+    value: { type: Types.Ref },
+    overrides: { type: Types.JSON, default: {} },
+  };
+}

--- a/src/components/mesh.ts
+++ b/src/components/mesh.ts
@@ -1,14 +1,4 @@
-import { Component, ComponentSchema, Types } from 'ecsy';
 import { AbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
+import InstanceComponent from './_instance';
 
-export default class MeshComponent extends Component<MeshComponent> {
-  value!: AbstractMesh | null;
-  overrides!: Record<string, unknown>;
-  _prevValue!: AbstractMesh | null;
-
-  static schema: ComponentSchema = {
-    value: { type: Types.Ref, default: null },
-    overrides: { type: Types.JSON, default: {} },
-    _prevValue: { type: Types.Ref, default: null },
-  };
-}
+export default class MeshComponent extends InstanceComponent<MeshComponent, AbstractMesh> {}

--- a/src/systems/mesh.ts
+++ b/src/systems/mesh.ts
@@ -24,7 +24,7 @@ export default class MeshSystem extends SystemWithCore {
   }
 
   setup(entity: Entity): void {
-    const meshComponent = entity.getMutableComponent(Mesh);
+    const meshComponent = entity.getComponent(Mesh);
 
     assert('MeshSystem needs BabylonCoreComponent', this.core);
     assert('Failed to add Mesh Component. No valid Mesh found.', !!meshComponent?.value);
@@ -37,26 +37,25 @@ export default class MeshSystem extends SystemWithCore {
 
     mesh.parent = transformNodeComponent.value;
     mesh.computeWorldMatrix(true); // @todo still needed?
-    meshComponent.value = mesh;
 
     const { value, overrides } = meshComponent;
     assign(value, overrides);
 
     this.core.scene.addMesh(mesh);
-    meshComponent._prevValue = mesh;
   }
 
   update(entity: Entity): void {
     const meshComponent = entity.getComponent(Mesh)!;
-    const previousMesh = meshComponent._prevValue;
+    const mesh = meshComponent.value;
+    const previousMesh = meshComponent.previousValue;
 
-    if (previousMesh && meshComponent.value !== previousMesh) {
+    if (previousMesh && mesh !== previousMesh) {
       this.removeMesh(previousMesh);
     }
 
     this.setup(entity);
-    if (previousMesh && meshComponent.value) {
-      meshComponent.value.material = previousMesh.material;
+    if (previousMesh && mesh) {
+      mesh.material = previousMesh.material;
     }
   }
 


### PR DESCRIPTION
Abstraction to handle Babylon instances, remembering the previous instance for proper teardown in systems. Used for now only as a Mesh component implementation, more to follow.