### PR TITLE
Don't add default camera to scene

### DIFF
--- a/src/components/babylon-core.ts
+++ b/src/components/babylon-core.ts
@@ -1,13 +1,11 @@
 import { Scene } from '@babylonjs/core/scene';
 import { Engine } from '@babylonjs/core/Engines/engine';
 import { Component, ComponentSchema, World, Types } from 'ecsy';
-import { Camera } from '@babylonjs/core/Cameras/camera';
 import { ShadowGenerator } from '@babylonjs/core/Lights/Shadows/shadowGenerator';
 
 export default class BabylonCore extends Component<BabylonCore> {
   world!: World;
   canvas!: HTMLCanvasElement;
-  defaultCamera!: Camera;
   engine!: Engine;
   scene!: Scene;
   shadowGenerators: Set<ShadowGenerator> = new Set();
@@ -19,9 +17,6 @@ export default class BabylonCore extends Component<BabylonCore> {
       type: Types.Ref,
     },
     canvas: {
-      type: Types.Ref,
-    },
-    defaultCamera: {
       type: Types.Ref,
     },
     engine: {

--- a/src/systems/babylon.ts
+++ b/src/systems/babylon.ts
@@ -1,9 +1,7 @@
 import { Entity, System } from 'ecsy';
 import { BabylonCore } from '../components';
 import { Scene } from '@babylonjs/core/scene';
-import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 import { Engine } from '@babylonjs/core/Engines/engine';
-import { FreeCamera } from '@babylonjs/core/Cameras/freeCamera';
 
 export default class BabylonSystem extends System {
   listener?: EventListener;
@@ -19,13 +17,13 @@ export default class BabylonSystem extends System {
     core.engine = core.engine || new Engine(core.canvas, true, {}, false);
     core.scene = new Scene(core.engine);
 
-    core.defaultCamera = new FreeCamera('defaultCamera', new Vector3(0, 0, -10), core.scene);
-    core.defaultCamera.attachControl(core.canvas, false);
-
     this.listener = function (this: { engine: Engine }): void {
       this.engine.resize();
     }.bind({ engine: core.engine });
 
+    // @todo do we really want to do this here? Or should we delegate the responsibility ot the consumer?
+    // For example the canvas might need to even react to resizing the canvas *element*, not just the
+    // while window, i.e. we would have to use a ResizeObserver
     window.addEventListener('resize', this.listener);
 
     const startTime = window.performance.now();

--- a/src/systems/camera.ts
+++ b/src/systems/camera.ts
@@ -18,16 +18,17 @@ export default class CameraSystem extends SystemWithCore {
     assert('CameraSystem needs BabylonCoreComponent', this.core);
 
     const { scene, canvas } = this.core;
-    const { value: instance } = entity.getComponent(Camera)!;
+    const { value: camera } = entity.getComponent(Camera)!;
 
-    assert('Failed to add Camera, no camera instance found.', instance);
+    assert('Failed to add Camera, no camera instance found.', camera);
 
-    scene.activeCamera = instance;
-    scene.activeCamera.attachControl(canvas, false);
+    scene.addCamera(camera);
+    scene.activeCamera = camera;
+    camera.attachControl(canvas, false);
 
     const transformNodeComponent = entity.getComponent(TransformNode);
     assert('TransformNode needed for cameras, add Parent component to fix', transformNodeComponent);
-    instance.parent = transformNodeComponent.value;
+    camera.parent = transformNodeComponent.value;
   }
 
   update(entity: Entity): void {
@@ -43,21 +44,8 @@ export default class CameraSystem extends SystemWithCore {
   remove(entity: Entity): void {
     assert('CameraSystem needs BabylonCoreComponent', this.core);
 
-    const { scene, canvas, defaultCamera } = this.core;
     const cameraComponent = entity.getRemovedComponent(Camera)!;
-
-    // TODO: We might need something smarter here in the future, what if there's multiple camera entities?
-    // set defaultCamera as current active camera if it exists
-    scene.activeCamera = defaultCamera || null;
-
-    if (scene.activeCamera) {
-      // restore control if there is still an active camera
-      scene.activeCamera.attachControl(canvas, false);
-    }
-
-    if (cameraComponent.value) {
-      cameraComponent.value.dispose();
-    }
+    cameraComponent.value?.dispose();
   }
 
   static queries = {

--- a/test/babylon.test.ts
+++ b/test/babylon.test.ts
@@ -30,10 +30,10 @@ describe('babylon system', function () {
 
     expect(beforeRender).toHaveBeenCalled();
     expect(beforeRender.mock.calls[0][0]).toBe(0);
-    expect(beforeRender.mock.calls[0][1]).toBeGreaterThan(10); // an animation frame
+    expect(beforeRender.mock.calls[0][1]).toBeGreaterThan(1); // an animation frame
 
     expect(afterRender).toHaveBeenCalled();
     expect(afterRender.mock.calls[0][0]).toBe(0);
-    expect(afterRender.mock.calls[0][1]).toBeGreaterThan(10); // an animation frame
+    expect(afterRender.mock.calls[0][1]).toBeGreaterThan(1); // an animation frame
   });
 });

--- a/test/camera.test.ts
+++ b/test/camera.test.ts
@@ -1,22 +1,10 @@
 import { ArcRotateCamera, TargetCamera, BabylonCore, Parent } from '../src/components';
 import { ArcRotateCamera as BabylonArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
 import { TargetCamera as BabylonTargetCamera } from '@babylonjs/core/Cameras/targetCamera';
-import { Camera } from '@babylonjs/core/Cameras/camera';
 import setupWorld from './helpers/setup-world';
 import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 
 describe('camera system', function () {
-  it('works with default camera', function () {
-    const { world, rootEntity } = setupWorld();
-
-    world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
-
-    expect(scene.activeCamera).toBeInstanceOf(Camera);
-    expect(scene.cameras).toHaveLength(1);
-  });
-
   describe('arc-rotate camera', function () {
     it('can add arc-rotate camera', function () {
       const { world, rootEntity } = setupWorld();
@@ -133,9 +121,8 @@ describe('camera system', function () {
       cameraEntity.remove();
       world.execute(0, 0);
 
-      expect(scene.activeCamera).toBeInstanceOf(Camera);
-      expect(scene.activeCamera).not.toEqual(camera);
-      expect(scene.cameras).toHaveLength(1);
+      expect(scene.activeCamera).toBeNull();
+      expect(scene.cameras).toHaveLength(0);
     });
 
     it('throws without parent component', function () {
@@ -236,9 +223,8 @@ describe('camera system', function () {
       cameraEntity.remove();
       world.execute(0, 0);
 
-      expect(scene.activeCamera).toBeInstanceOf(Camera);
-      expect(scene.activeCamera).not.toEqual(camera);
-      expect(scene.cameras).toHaveLength(1);
+      expect(scene.activeCamera).toBeNull();
+      expect(scene.cameras).toHaveLength(0);
     });
   });
 });

--- a/test/mesh.test.ts
+++ b/test/mesh.test.ts
@@ -40,7 +40,7 @@ describe('mesh system', function () {
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.transformNodes).toHaveLength(1);
-    expect(scene.rootNodes).toHaveLength(2); // TN + default camera
+    expect(scene.rootNodes).toHaveLength(1);
 
     const mesh = scene.meshes[0];
     const tn = scene.transformNodes[0];


### PR DESCRIPTION
The previous behavior was not really useful, as you will pretty much always add an explicit camera that you can control. Also this always imports the `FreeCamera` even if not used, and attaches useless event listeners.