### PR TITLE
Revert rotation unit back from degrees to radians

### DIFF
--- a/src/systems/transform.ts
+++ b/src/systems/transform.ts
@@ -4,7 +4,6 @@ import guidFor from '../-private/utils/guid';
 import { assert } from '../-private/utils/debug';
 import { TransformNode as BabylonTransformNode } from '@babylonjs/core/Meshes/transformNode';
 import { World } from '../index';
-import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 
 export default class TransformSystem extends System<Entity> {
   world!: World;
@@ -115,32 +114,21 @@ export default class TransformSystem extends System<Entity> {
   }
 
   setRotation(entity: Entity): void {
-    const rotationComponent = entity.getComponent(Rotation)!;
-
-    let { x, y, z } = rotationComponent.value;
-
-    x = (x * Math.PI) / 180;
-    y = (y * Math.PI) / 180;
-    z = (z * Math.PI) / 180;
-
-    this.world.babylonManager.setProperty(entity, this.getTransformNode(entity), 'rotation', new Vector3(x, y, z));
+    this.world.babylonManager.setProperty(
+      entity,
+      this.getTransformNode(entity),
+      'rotation',
+      entity.getComponent(Rotation)!.value
+    );
   }
 
   updateRotation(entity: Entity): void {
-    const rotationComponent = entity.getComponent(Rotation)!;
-
-    let { x, y, z } = rotationComponent.value;
-
-    x = (x * Math.PI) / 180;
-    y = (y * Math.PI) / 180;
-    z = (z * Math.PI) / 180;
-
     this.world.babylonManager.updateProperty(
       entity,
       this.getTransformNode(entity),
       'transform',
       'rotation',
-      new Vector3(x, y, z)
+      entity.getComponent(Rotation)!.value
     );
   }
 

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -70,7 +70,7 @@ describe('transform system', function () {
       entity
         .addComponent(Parent)
         .addComponent(Box)
-        .addComponent(Rotation, { value: new Vector3(0, 180, 0) });
+        .addComponent(Rotation, { value: new Vector3(0, Math.PI, 0) });
 
       world.execute(0, 0);
 
@@ -93,7 +93,7 @@ describe('transform system', function () {
 
       const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Rotation)!;
-      component.value = new Vector3(0, 180, 0);
+      component.value = new Vector3(0, Math.PI, 0);
 
       world.execute(0, 0);
 

--- a/test/transition.test.ts
+++ b/test/transition.test.ts
@@ -630,7 +630,7 @@ describe('transform system', function () {
 
       const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Rotation)!;
-      component.value = new Vector3(0, 180, 0);
+      component.value = new Vector3(0, Math.PI, 0);
 
       world.execute(0, 0);
 


### PR DESCRIPTION
Users can define simple helpers to help with the conversion, but the default here should match what Babylon.js expects.

Fixes #290 