### PR TITLE
Drop own resize handling

### DIFF
--- a/src/systems/babylon.ts
+++ b/src/systems/babylon.ts
@@ -17,15 +17,6 @@ export default class BabylonSystem extends System {
     core.engine = core.engine || new Engine(core.canvas, true, {}, false);
     core.scene = new Scene(core.engine);
 
-    this.listener = function (this: { engine: Engine }): void {
-      this.engine.resize();
-    }.bind({ engine: core.engine });
-
-    // @todo do we really want to do this here? Or should we delegate the responsibility ot the consumer?
-    // For example the canvas might need to even react to resizing the canvas *element*, not just the
-    // while window, i.e. we would have to use a ResizeObserver
-    window.addEventListener('resize', this.listener);
-
     const startTime = window.performance.now();
     core.engine.runRenderLoop((): void => {
       if (!core.engine || !core.scene) {


### PR DESCRIPTION
This is better done by the libraries' consumer, as use cases can be different, e.g. the current resize event listeners (that only detects resizing the whole browser) might need to be replaced with a ResizeObserver (that also detects changes in size *within* the page).