### PR TITLE
Ensure we always explicitly pass `Scene` when creating new objects

### DIFF
--- a/src/-private/systems/with-core.ts
+++ b/src/-private/systems/with-core.ts
@@ -1,8 +1,8 @@
-import { Entity, System } from 'ecsy';
+import { System } from 'ecsy';
 import { BabylonCore } from '../../components';
 import World from '../../world';
 
-export default class SystemWithCore extends System<Entity> {
+export default class SystemWithCore extends System {
   world!: World;
   core?: BabylonCore;
 

--- a/src/systems/light/directional.ts
+++ b/src/systems/light/directional.ts
@@ -5,7 +5,6 @@ import FactorySystem from '../../-private/systems/factory';
 import { assign } from '../../-private/utils/assign';
 import { assert } from '../../-private/utils/debug';
 import Light from '../../components/light';
-import { Scene } from '@babylonjs/core/scene';
 
 export default class DirectionalLightSystem extends FactorySystem<
   DirectionalLight,
@@ -19,11 +18,7 @@ export default class DirectionalLightSystem extends FactorySystem<
     assert('DirectionalLightSystem needs BabylonCoreComponent', this.core);
 
     const { direction, ...options } = c;
-    const instance = new BabylonDirectionalLight(
-      DirectionalLight.name,
-      direction,
-      null as unknown as Scene // passing null is actually possible, but the typings require a Scene
-    );
+    const instance = new BabylonDirectionalLight(DirectionalLight.name, direction, this.core.scene);
     assign(instance, options);
 
     return instance;

--- a/src/systems/light/hemispheric.ts
+++ b/src/systems/light/hemispheric.ts
@@ -5,7 +5,6 @@ import FactorySystem from '../../-private/systems/factory';
 import { assign } from '../../-private/utils/assign';
 import { assert } from '../../-private/utils/debug';
 import Light from '../../components/light';
-import { Scene } from '@babylonjs/core/scene';
 
 export default class HemisphericLightSystem extends FactorySystem<
   HemisphericLight,
@@ -19,11 +18,7 @@ export default class HemisphericLightSystem extends FactorySystem<
     assert('HemisphericLightSystem needs BabylonCoreComponent', this.core);
 
     const { direction, ...options } = c;
-    const instance = new BabylonHemisphericLight(
-      HemisphericLight.name,
-      direction,
-      null as unknown as Scene // passing null is actually possible, but the typings require a Scene
-    );
+    const instance = new BabylonHemisphericLight(HemisphericLight.name, direction, this.core.scene);
     assign(instance, options);
 
     return instance;

--- a/src/systems/light/point.ts
+++ b/src/systems/light/point.ts
@@ -5,7 +5,6 @@ import FactorySystem from '../../-private/systems/factory';
 import { assign } from '../../-private/utils/assign';
 import { assert } from '../../-private/utils/debug';
 import Light from '../../components/light';
-import { Scene } from '@babylonjs/core/scene';
 
 export default class PointLightSystem extends FactorySystem<PointLight, Light<BabylonPointLight>, BabylonPointLight> {
   protected instanceComponentConstructor = Light;
@@ -15,11 +14,7 @@ export default class PointLightSystem extends FactorySystem<PointLight, Light<Ba
     assert('PointLightSystem needs BabylonCoreComponent', this.core);
 
     const { position, ...options } = c;
-    const instance = new BabylonPointLight(
-      PointLight.name,
-      position,
-      null as unknown as Scene // passing null is actually possible, but the typings require a Scene
-    );
+    const instance = new BabylonPointLight(PointLight.name, position, this.core.scene);
     assign(instance, options);
 
     return instance;

--- a/src/systems/light/spot.ts
+++ b/src/systems/light/spot.ts
@@ -5,7 +5,6 @@ import FactorySystem from '../../-private/systems/factory';
 import { assign } from '../../-private/utils/assign';
 import { assert } from '../../-private/utils/debug';
 import Light from '../../components/light';
-import { Scene } from '@babylonjs/core/scene';
 
 export default class SpotLightSystem extends FactorySystem<SpotLight, Light<BabylonSpotLight>, BabylonSpotLight> {
   protected instanceComponentConstructor = Light;
@@ -15,14 +14,7 @@ export default class SpotLightSystem extends FactorySystem<SpotLight, Light<Baby
     assert('SpotLightSystem needs BabylonCoreComponent', this.core);
 
     const { direction, position, angle, exponent, ...options } = c;
-    const instance = new BabylonSpotLight(
-      SpotLight.name,
-      position,
-      direction,
-      angle,
-      exponent,
-      null as unknown as Scene // passing null is actually possible, but the typings require a Scene
-    );
+    const instance = new BabylonSpotLight(SpotLight.name, position, direction, angle, exponent, this.core.scene);
     assign(instance, options);
 
     return instance;

--- a/src/systems/material/background.ts
+++ b/src/systems/material/background.ts
@@ -1,4 +1,4 @@
-import { Material, BackgroundMaterial } from '../../components';
+import { BackgroundMaterial, Material } from '../../components';
 import { BackgroundMaterial as BabylonBackgroundMaterial } from '@babylonjs/core/Materials/Background/backgroundMaterial';
 import { queries } from '../../-private/systems/with-core';
 import FactorySystem from '../../-private/systems/factory';

--- a/src/systems/mesh.ts
+++ b/src/systems/mesh.ts
@@ -1,5 +1,5 @@
 import { Entity } from 'ecsy';
-import { Mesh, TransformNode, Material } from '../components';
+import { Material, Mesh, TransformNode } from '../components';
 import SystemWithCore, { queries } from '../-private/systems/with-core';
 import { assert } from '../-private/utils/debug';
 import { assign } from '../-private/utils/assign';

--- a/src/systems/primitive/box.ts
+++ b/src/systems/primitive/box.ts
@@ -13,7 +13,7 @@ export default class BoxPrimitiveSystem extends FactorySystem<Box, Mesh<BabylonM
     assert('BoxPrimitiveSystem needs BabylonCoreComponent', this.core);
 
     // Babylon's Builder unfortunately mutate the passed options, so we need to spread to clone them
-    return BoxBuilder.CreateBox(Box.name, { ...c });
+    return BoxBuilder.CreateBox(Box.name, { ...c }, this.core.scene);
   }
 
   static queries = {

--- a/src/systems/primitive/lines.ts
+++ b/src/systems/primitive/lines.ts
@@ -14,7 +14,7 @@ export default class LinesPrimitiveSystem extends FactorySystem<Lines, Mesh<Baby
 
     const { color, alpha, ...rest } = c;
 
-    const linesMesh = LinesBuilder.CreateLines(Lines.name, rest);
+    const linesMesh = LinesBuilder.CreateLines(Lines.name, rest, this.core.scene);
     if (color) {
       linesMesh.color = color;
     }

--- a/src/systems/primitive/plane.ts
+++ b/src/systems/primitive/plane.ts
@@ -1,4 +1,4 @@
-import { Plane, Mesh } from '../../components';
+import { Mesh, Plane } from '../../components';
 import { Mesh as BabylonMesh } from '@babylonjs/core/Meshes/mesh';
 import { queries } from '../../-private/systems/with-core';
 import FactorySystem from '../../-private/systems/factory';
@@ -13,7 +13,7 @@ export default class PlanePrimitiveSystem extends FactorySystem<Plane, Mesh<Baby
     assert('PlanePrimitiveSystem needs BabylonCoreComponent', this.core);
 
     // Babylon's Builder unfortunately mutate the passed options, so we need to spread to clone them
-    return PlaneBuilder.CreatePlane(Plane.name, { ...c });
+    return PlaneBuilder.CreatePlane(Plane.name, { ...c }, this.core.scene);
   }
 
   static queries = {

--- a/src/systems/primitive/sphere.ts
+++ b/src/systems/primitive/sphere.ts
@@ -1,4 +1,4 @@
-import { Sphere, Mesh } from '../../components';
+import { Mesh, Sphere } from '../../components';
 import { Mesh as BabylonMesh } from '@babylonjs/core/Meshes/mesh';
 import { queries } from '../../-private/systems/with-core';
 import FactorySystem from '../../-private/systems/factory';
@@ -13,7 +13,7 @@ export default class SpherePrimitiveSystem extends FactorySystem<Sphere, Mesh<Ba
     assert('SpherePrimitiveSystem needs BabylonCoreComponent', this.core);
 
     // Babylon's Builder unfortunately mutate the passed options, so we need to spread to clone them
-    return SphereBuilder.CreateSphere(Sphere.name, { ...c });
+    return SphereBuilder.CreateSphere(Sphere.name, { ...c }, this.core.scene);
   }
 
   static queries = {

--- a/src/systems/transition.ts
+++ b/src/systems/transition.ts
@@ -5,7 +5,7 @@ import BabylonWorld from '../world';
 import { Animation } from '@babylonjs/core/Animations/animation';
 import '@babylonjs/core/Animations/animatable'; // needed to enable animation support on Scene in a tree-shaken build
 
-export default class TransitionSystem extends System<Entity> {
+export default class TransitionSystem extends System {
   world!: World;
 
   constructor(world: BabylonWorld, attributes: Attributes) {

--- a/test/babylon.test.ts
+++ b/test/babylon.test.ts
@@ -4,9 +4,8 @@ import setupWorld from './helpers/setup-world';
 
 describe('babylon system', function () {
   it('sets up babylon scene', function () {
-    const { world, rootEntity } = setupWorld();
+    const { rootEntity } = setupWorld();
 
-    world.execute(0, 0);
     const babylonComponent = rootEntity.getComponent(BabylonCore)!;
 
     expect(babylonComponent.engine).toBeDefined();
@@ -17,14 +16,12 @@ describe('babylon system', function () {
     const beforeRender = jest.fn<void, [number, number]>();
     const afterRender = jest.fn<void, [number, number]>();
 
-    const { world } = setupWorld({
+    setupWorld({
       rootEntityValues: {
         beforeRender,
         afterRender,
       },
     });
-
-    world.execute(0, 0);
 
     await waitForRAF();
 

--- a/test/camera.test.ts
+++ b/test/camera.test.ts
@@ -1,4 +1,4 @@
-import { ArcRotateCamera, TargetCamera, BabylonCore, Parent } from '../src/components';
+import { ArcRotateCamera, Parent, TargetCamera } from '../src/components';
 import { ArcRotateCamera as BabylonArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera';
 import { TargetCamera as BabylonTargetCamera } from '@babylonjs/core/Cameras/targetCamera';
 import setupWorld from './helpers/setup-world';
@@ -7,14 +7,12 @@ import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 describe('camera system', function () {
   describe('arc-rotate camera', function () {
     it('can add arc-rotate camera', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.activeCamera).toBeInstanceOf(BabylonArcRotateCamera);
       expect(scene.cameras).toHaveLength(2);
@@ -32,7 +30,7 @@ describe('camera system', function () {
     });
 
     it('can add arc-rotate camera with custom arguments', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera, {
@@ -49,8 +47,6 @@ describe('camera system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       expect(scene.activeCamera).toBeInstanceOf(BabylonArcRotateCamera);
 
       const camera = scene.activeCamera as BabylonArcRotateCamera;
@@ -66,14 +62,12 @@ describe('camera system', function () {
     });
 
     it('can update arc-rotate camera', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.activeCamera).toBeInstanceOf(BabylonArcRotateCamera);
 
@@ -106,14 +100,13 @@ describe('camera system', function () {
     });
 
     it('can remove arc-rotate camera', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const camera = scene.activeCamera;
 
       expect(camera).toBeInstanceOf(BabylonArcRotateCamera);
@@ -137,14 +130,12 @@ describe('camera system', function () {
 
   describe('target camera', function () {
     it('can add target camera', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(TargetCamera);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.activeCamera).toBeInstanceOf(BabylonTargetCamera);
       expect(scene.cameras).toHaveLength(2);
@@ -156,7 +147,7 @@ describe('camera system', function () {
     });
 
     it('can add target camera with custom arguments', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(TargetCamera, {
@@ -166,8 +157,6 @@ describe('camera system', function () {
       });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.activeCamera).toBeInstanceOf(BabylonTargetCamera);
 
@@ -179,14 +168,12 @@ describe('camera system', function () {
     });
 
     it('can update target camera', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(TargetCamera);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.activeCamera).toBeInstanceOf(BabylonTargetCamera);
 
@@ -208,14 +195,13 @@ describe('camera system', function () {
     });
 
     it('can remove target camera', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const cameraEntity = world.createEntity();
       cameraEntity.addComponent(Parent).addComponent(TargetCamera);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const camera = scene.activeCamera;
 
       expect(camera).toBeInstanceOf(BabylonTargetCamera);

--- a/test/helpers/setup-world.ts
+++ b/test/helpers/setup-world.ts
@@ -10,6 +10,7 @@ export interface SetupWorld {
   world: World;
   rootEntity: Entity;
   engine: Engine;
+  scene: Scene;
 }
 
 export interface SetupWorldOptions {
@@ -42,6 +43,7 @@ export default function setupWorld(options: SetupWorldOptions = {}): SetupWorld 
   });
 
   world.execute(0, 0);
+  const { scene } = rootEntity.getComponent(BabylonCore)!;
 
   // This has the side effect that Engine.LastCreatedScene is null, which forces us to always explicitly pass a Scene
   // when created new Babylon instances that require it. Omitting to do that works in general, as Babylon will then use
@@ -54,5 +56,6 @@ export default function setupWorld(options: SetupWorldOptions = {}): SetupWorld 
     world,
     rootEntity,
     engine,
+    scene,
   };
 }

--- a/test/helpers/setup-world.ts
+++ b/test/helpers/setup-world.ts
@@ -4,6 +4,7 @@ import { components, systems, World } from '../../src';
 import { NullEngine } from '@babylonjs/core/Engines/nullEngine';
 import { Component } from 'ecsy/src/Component';
 import { Engine } from '@babylonjs/core/Engines/engine';
+import { Scene } from '@babylonjs/core/scene';
 
 export interface SetupWorld {
   world: World;
@@ -39,6 +40,15 @@ export default function setupWorld(options: SetupWorldOptions = {}): SetupWorld 
     engine,
     ...(options.rootEntityValues ?? {}),
   });
+
+  world.execute(0, 0);
+
+  // This has the side effect that Engine.LastCreatedScene is null, which forces us to always explicitly pass a Scene
+  // when created new Babylon instances that require it. Omitting to do that works in general, as Babylon will then use
+  // this Engine.LastCreatedScene, but this can break when dealing with multiple Scenes in a single browser session (e.g.
+  // adding and tearing down a new <canvas> in a SPA).
+  const dummyScene = new Scene(engine);
+  dummyScene.dispose();
 
   return {
     world,

--- a/test/light.test.ts
+++ b/test/light.test.ts
@@ -1,4 +1,4 @@
-import { BabylonCore, Parent, PointLight, DirectionalLight, HemisphericLight, SpotLight } from '../src/components';
+import { DirectionalLight, HemisphericLight, Parent, PointLight, SpotLight } from '../src/components';
 import { PointLight as BabylonPointLight } from '@babylonjs/core/Lights/pointLight';
 import { DirectionalLight as BabylonDirectionalLight } from '@babylonjs/core/Lights/directionalLight';
 import { SpotLight as BabylonSpotLight } from '@babylonjs/core/Lights/spotLight';
@@ -9,14 +9,12 @@ import setupWorld from './helpers/setup-world';
 describe('light system', function () {
   describe('point-light', function () {
     it('can add point-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(PointLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -26,14 +24,12 @@ describe('light system', function () {
     });
 
     it('can add point-light with custom arguments', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(PointLight, { intensity: 2 });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -43,14 +39,13 @@ describe('light system', function () {
     });
 
     it('can update point-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(PointLight);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = lightEntity.getMutableComponent(PointLight)!;
       component.intensity = 2;
 
@@ -64,14 +59,12 @@ describe('light system', function () {
     });
 
     it('can remove point-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(PointLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       lightEntity.remove();
       world.execute(0, 0);
@@ -81,14 +74,12 @@ describe('light system', function () {
   });
   describe('directional-light', function () {
     it('can add directional-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(DirectionalLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -99,7 +90,7 @@ describe('light system', function () {
     });
 
     it('can add directional-light with custom arguments', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity
@@ -107,8 +98,6 @@ describe('light system', function () {
         .addComponent(DirectionalLight, { intensity: 2, direction: new Vector3(1, 0, 0) });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -119,14 +108,13 @@ describe('light system', function () {
     });
 
     it('can update directional-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(DirectionalLight);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = lightEntity.getMutableComponent(DirectionalLight)!;
       component.intensity = 2;
       component.direction = new Vector3(1, 0, 0);
@@ -142,14 +130,12 @@ describe('light system', function () {
     });
 
     it('can remove directional-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(DirectionalLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       lightEntity.remove();
       world.execute(0, 0);
@@ -159,14 +145,12 @@ describe('light system', function () {
   });
   describe('spot-light', function () {
     it('can add spot-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(SpotLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -179,7 +163,7 @@ describe('light system', function () {
     });
 
     it('can add spot-light with custom arguments', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity
@@ -187,8 +171,6 @@ describe('light system', function () {
         .addComponent(SpotLight, { intensity: 2, direction: new Vector3(1, 0, 0), angle: Math.PI, exponent: 1 });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -201,14 +183,13 @@ describe('light system', function () {
     });
 
     it('can update spot-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(SpotLight);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = lightEntity.getMutableComponent(SpotLight)!;
       Object.assign(component, { intensity: 2, direction: new Vector3(1, 0, 0), angle: Math.PI, exponent: 1 });
 
@@ -225,14 +206,12 @@ describe('light system', function () {
     });
 
     it('can remove spot-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(SpotLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       lightEntity.remove();
       world.execute(0, 0);
@@ -243,14 +222,12 @@ describe('light system', function () {
 
   describe('hemispheric-light', function () {
     it('can add hemispheric-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(HemisphericLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -261,7 +238,7 @@ describe('light system', function () {
     });
 
     it('can add hemispheric-light with custom arguments', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity
@@ -269,8 +246,6 @@ describe('light system', function () {
         .addComponent(HemisphericLight, { intensity: 2, direction: new Vector3(1, 0, 0) });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.lights).toHaveLength(1);
 
@@ -281,14 +256,13 @@ describe('light system', function () {
     });
 
     it('can update hemispheric-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(HemisphericLight);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = lightEntity.getMutableComponent(HemisphericLight)!;
       component.intensity = 2;
       component.direction = new Vector3(1, 0, 0);
@@ -304,14 +278,12 @@ describe('light system', function () {
     });
 
     it('can remove hemispheric-light', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const lightEntity = world.createEntity();
       lightEntity.addComponent(Parent).addComponent(HemisphericLight);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       lightEntity.remove();
       world.execute(0, 0);

--- a/test/material.test.ts
+++ b/test/material.test.ts
@@ -1,4 +1,4 @@
-import { BabylonCore, Box, Parent, PbrMaterial, StandardMaterial } from '../src/components';
+import { Box, Parent, PbrMaterial, StandardMaterial } from '../src/components';
 import { Color3 } from '@babylonjs/core/Maths/math.color';
 import { PBRMaterial as BabylonPBRMaterial } from '@babylonjs/core/Materials/PBR/pbrMaterial';
 import setupWorld from './helpers/setup-world';
@@ -8,14 +8,13 @@ import Material from '../src/components/material';
 describe('material system', function () {
   describe('pbr material', function () {
     it('can add material', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(PbrMaterial);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const material = scene.getMaterialByName('PbrMaterial') as BabylonPBRMaterial;
 
       expect(material).toBeInstanceOf(BabylonPBRMaterial);
@@ -24,7 +23,7 @@ describe('material system', function () {
     });
 
     it('can add material with custom values', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -40,7 +39,6 @@ describe('material system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const material = scene.getMaterialByName('PbrMaterial') as BabylonPBRMaterial;
 
       expect(material).toBeInstanceOf(BabylonPBRMaterial);
@@ -53,14 +51,13 @@ describe('material system', function () {
     });
 
     it('can update material', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(PbrMaterial);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(PbrMaterial);
       Object.assign(component, {
         albedoColor: new Color3(1, 0, 0),
@@ -84,7 +81,7 @@ describe('material system', function () {
     });
 
     it('can apply material to updated mesh', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -94,7 +91,6 @@ describe('material system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Box)!;
       component.size = 2;
 
@@ -108,14 +104,12 @@ describe('material system', function () {
     });
 
     it('can remove material', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(PbrMaterial);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       entity.removeComponent(PbrMaterial);
       world.execute(0, 0);
@@ -127,14 +121,12 @@ describe('material system', function () {
     });
 
     it('can remove whole entity', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(PbrMaterial);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       entity.remove();
       world.execute(0, 0);
@@ -147,14 +139,13 @@ describe('material system', function () {
 
   describe('standard material', function () {
     it('can add material', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(StandardMaterial);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const material = scene.getMaterialByName('StandardMaterial') as BabylonStandardMaterial;
 
       expect(material).toBeInstanceOf(BabylonStandardMaterial);
@@ -163,7 +154,7 @@ describe('material system', function () {
     });
 
     it('can add material with custom values', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -177,7 +168,6 @@ describe('material system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const material = scene.getMaterialByName('StandardMaterial') as BabylonStandardMaterial;
 
       expect(material).toBeInstanceOf(BabylonStandardMaterial);
@@ -188,14 +178,13 @@ describe('material system', function () {
     });
 
     it('can update material', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(StandardMaterial);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(StandardMaterial);
       Object.assign(component, {
         diffuseColor: new Color3(1, 0, 0),
@@ -215,14 +204,12 @@ describe('material system', function () {
     });
 
     it('can remove material', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(StandardMaterial);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       entity.removeComponent(StandardMaterial);
       world.execute(0, 0);
@@ -236,12 +223,11 @@ describe('material system', function () {
 
   describe('material', function () {
     it('can add material instance', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       world.execute(0, 0);
 
       const entity = world.createEntity();
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const material = new BabylonPBRMaterial('PbrMaterial', scene);
       entity.addComponent(Parent).addComponent(Box).addComponent(Material, { value: material });
@@ -252,12 +238,11 @@ describe('material system', function () {
     });
 
     it('can update material instance', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       world.execute(0, 0);
 
       const entity = world.createEntity();
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const material = new BabylonPBRMaterial('PbrMaterial', scene);
       entity.addComponent(Parent).addComponent(Box).addComponent(Material, { value: material });
@@ -274,12 +259,11 @@ describe('material system', function () {
     });
 
     it('can remove material instance', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       world.execute(0, 0);
 
       const entity = world.createEntity();
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const material = new BabylonPBRMaterial('PbrMaterial', scene);
       entity.addComponent(Parent).addComponent(Box).addComponent(Material, { value: material });

--- a/test/mesh.test.ts
+++ b/test/mesh.test.ts
@@ -1,21 +1,16 @@
-import { BabylonCore, Mesh, Parent } from '../src/components';
+import { Mesh, Parent } from '../src/components';
 import setupWorld from './helpers/setup-world';
 import { BoxBuilder } from '@babylonjs/core/Meshes/Builders/boxBuilder';
 import { Mesh as BabylonMesh } from '@babylonjs/core/Meshes/mesh';
 
 describe('mesh system', function () {
   it('can add mesh', function () {
-    const { world, rootEntity } = setupWorld();
-
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
+    const { world, scene } = setupWorld();
 
     const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }) });
+    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }, scene) });
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.geometries).toHaveLength(1);
@@ -26,17 +21,12 @@ describe('mesh system', function () {
   });
 
   it('integrates with transformNodes properly', function () {
-    const { world, rootEntity } = setupWorld();
-
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
+    const { world, scene } = setupWorld();
 
     const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }) });
+    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }, scene) });
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.transformNodes).toHaveLength(1);
@@ -52,17 +42,12 @@ describe('mesh system', function () {
   });
 
   it('can update mesh', function () {
-    const { world, rootEntity } = setupWorld();
-
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
+    const { world, scene } = setupWorld();
 
     const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('box1', { size: 1 }) });
+    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('box1', { size: 1 }, scene) });
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.geometries).toHaveLength(1);
@@ -72,7 +57,7 @@ describe('mesh system', function () {
     const meshComponent = entity.getMutableComponent(Mesh)!;
     expect(meshComponent).toBeDefined();
 
-    meshComponent.value = BoxBuilder.CreateBox('box2', { size: 1 });
+    meshComponent.value = BoxBuilder.CreateBox('box2', { size: 1 }, scene);
 
     world.execute(0, 0);
 
@@ -83,17 +68,12 @@ describe('mesh system', function () {
   });
 
   it('can remove mesh', function () {
-    const { world, rootEntity } = setupWorld();
-
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
+    const { world, scene } = setupWorld();
 
     const entity = world.createEntity();
-    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }) });
+    entity.addComponent(Parent).addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }, scene) });
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.geometries).toHaveLength(1);
@@ -106,20 +86,15 @@ describe('mesh system', function () {
   });
 
   it('does not remove mesh used elsewhere', function () {
-    const { world, rootEntity } = setupWorld();
+    const { world, scene } = setupWorld();
 
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
-
-    const mesh = BoxBuilder.CreateBox('test', { size: 1 });
+    const mesh = BoxBuilder.CreateBox('test', { size: 1 }, scene);
     const entity1 = world.createEntity();
     const entity2 = world.createEntity();
     entity1.addComponent(Parent).addComponent(Mesh, { value: mesh });
     entity2.addComponent(Parent);
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.geometries).toHaveLength(1);
@@ -142,19 +117,14 @@ describe('mesh system', function () {
   });
 
   it('can override mesh properties', function () {
-    const { world, rootEntity } = setupWorld();
-
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
+    const { world, scene } = setupWorld();
 
     const entity = world.createEntity();
     entity
       .addComponent(Parent)
-      .addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }), overrides: { isVisible: false } });
+      .addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }, scene), overrides: { isVisible: false } });
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.geometries).toHaveLength(1);
@@ -166,19 +136,14 @@ describe('mesh system', function () {
   });
 
   it('can update overridden mesh properties', function () {
-    const { world, rootEntity } = setupWorld();
-
-    // wait for scene to be created before creating meshes
-    world.execute(0, 0);
+    const { world, scene } = setupWorld();
 
     const entity = world.createEntity();
     entity
       .addComponent(Parent)
-      .addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }), overrides: { isVisible: false } });
+      .addComponent(Mesh, { value: BoxBuilder.CreateBox('test', { size: 1 }, scene), overrides: { isVisible: false } });
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.meshes).toHaveLength(1);
     expect(scene.geometries).toHaveLength(1);

--- a/test/post-process-render-pipeline.test.ts
+++ b/test/post-process-render-pipeline.test.ts
@@ -1,6 +1,5 @@
 import {
   ArcRotateCamera,
-  BabylonCore,
   DefaultRenderingPipeline,
   Parent,
   PostProcessRenderPipeline,
@@ -44,7 +43,7 @@ function createPipeline(engine: Engine, name = 'test'): BabylonPostProcessRender
 describe('post-process-render-pipeline system', function () {
   describe('post-process-render-pipeline', function () {
     it('can add PostProcessRenderPipeline instances', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = createPipeline(engine, 'test');
 
@@ -55,8 +54,6 @@ describe('post-process-render-pipeline system', function () {
         .addComponent(PostProcessRenderPipeline, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.postProcessRenderPipelineManager.supportedPipelines).toHaveLength(1);
       expect(scene.postProcessRenderPipelineManager.supportedPipelines[0]).toEqual(pp);
@@ -65,7 +62,7 @@ describe('post-process-render-pipeline system', function () {
     });
 
     it('can add another postprocessing instance', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = createPipeline(engine, 'test');
 
@@ -76,8 +73,6 @@ describe('post-process-render-pipeline system', function () {
         .addComponent(PostProcessRenderPipeline, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const component = cameraEntity.getMutableComponent(PostProcessRenderPipeline)!;
       const pp2 = createPipeline(engine, 'test2');
@@ -94,7 +89,7 @@ describe('post-process-render-pipeline system', function () {
     });
 
     it('can remove a postprocessing instance', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = createPipeline(engine, 'test');
       const pp2 = createPipeline(engine, 'test2');
@@ -106,8 +101,6 @@ describe('post-process-render-pipeline system', function () {
         .addComponent(PostProcessRenderPipeline, { value: [pp, pp2] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const component = cameraEntity.getMutableComponent(PostProcessRenderPipeline)!;
       component.value = [pp];
@@ -123,7 +116,7 @@ describe('post-process-render-pipeline system', function () {
     });
 
     it('can remove postprocessing instances', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = createPipeline(engine, 'test');
 
@@ -134,8 +127,6 @@ describe('post-process-render-pipeline system', function () {
         .addComponent(PostProcessRenderPipeline, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       cameraEntity.removeComponent(PostProcessRenderPipeline);
       world.execute(0, 0);
@@ -147,7 +138,7 @@ describe('post-process-render-pipeline system', function () {
     });
 
     it('can remove the whole entity', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = createPipeline(engine, 'test');
 
@@ -159,8 +150,6 @@ describe('post-process-render-pipeline system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       cameraEntity.remove();
       world.execute(0, 0);
 
@@ -171,14 +160,12 @@ describe('post-process-render-pipeline system', function () {
   describe('builders', function () {
     describe('default', function () {
       it('can add post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(DefaultRenderingPipeline);
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcessRenderPipelineManager.supportedPipelines).toHaveLength(1);
         const pp = scene.postProcessRenderPipelineManager.supportedPipelines[0] as BabylonDefaultRenderingPipeline;
@@ -195,7 +182,7 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can add post-process with custom properties', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity
@@ -214,8 +201,6 @@ describe('post-process-render-pipeline system', function () {
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
-
         expect(scene.postProcessRenderPipelineManager.supportedPipelines).toHaveLength(1);
         const pp = scene.postProcessRenderPipelineManager.supportedPipelines[0] as BabylonDefaultRenderingPipeline;
         expect(pp).toBeInstanceOf(BabylonDefaultRenderingPipeline);
@@ -232,14 +217,13 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can update post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(DefaultRenderingPipeline);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         const c = cameraEntity.getMutableComponent(DefaultRenderingPipeline);
         Object.assign(c, {
           sharpenEnabled: true,
@@ -268,14 +252,13 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can remove post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(DefaultRenderingPipeline);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.removeComponent(DefaultRenderingPipeline);
 
         world.execute(0, 0);
@@ -287,14 +270,13 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can remove the whole entity', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(DefaultRenderingPipeline);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.remove();
 
         world.execute(0, 0);
@@ -308,14 +290,12 @@ describe('post-process-render-pipeline system', function () {
     // we cannot test this, as this requires canvas support in node. Could install `canvas` package, for now skipping tests...
     describe.skip('ssao', function () {
       it('can add post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(SsaoRenderingPipeline);
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcessRenderPipelineManager.supportedPipelines).toHaveLength(1);
         const pp = scene.postProcessRenderPipelineManager.supportedPipelines[0] as BabylonSSAORenderingPipeline;
@@ -326,7 +306,7 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can add post-process with custom properties', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(SsaoRenderingPipeline, {
@@ -336,8 +316,6 @@ describe('post-process-render-pipeline system', function () {
         });
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcessRenderPipelineManager.supportedPipelines).toHaveLength(1);
         const pp = scene.postProcessRenderPipelineManager.supportedPipelines[0] as BabylonSSAORenderingPipeline;
@@ -351,14 +329,13 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can update post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(SsaoRenderingPipeline);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         const c = cameraEntity.getMutableComponent(SsaoRenderingPipeline);
         Object.assign(c, {
           name: 'test',
@@ -380,14 +357,13 @@ describe('post-process-render-pipeline system', function () {
       });
 
       it('can remove post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(SsaoRenderingPipeline);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.removeComponent(SsaoRenderingPipeline);
 
         world.execute(0, 0);

--- a/test/post-processing.test.ts
+++ b/test/post-processing.test.ts
@@ -1,11 +1,10 @@
 import {
   ArcRotateCamera,
-  BabylonCore,
+  BlackAndWhitePostProcess,
+  BlurPostProcess,
+  MotionBlurPostProcess,
   Parent,
   PostProcess,
-  BlurPostProcess,
-  BlackAndWhitePostProcess,
-  MotionBlurPostProcess,
 } from '../src/components';
 import setupWorld from './helpers/setup-world';
 import { PassPostProcess } from '@babylonjs/core/PostProcesses/passPostProcess';
@@ -17,7 +16,7 @@ import { Vector2 } from '@babylonjs/core/Maths/math.vector';
 describe('post-processing system', function () {
   describe('post-process', function () {
     it('can add postprocessing instances', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = new PassPostProcess('pass', 1.0, null, undefined, engine);
 
@@ -28,8 +27,6 @@ describe('post-processing system', function () {
         .addComponent(PostProcess, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.postProcesses).toHaveLength(1);
       expect(scene.postProcesses[0]).toEqual(pp);
@@ -39,7 +36,7 @@ describe('post-processing system', function () {
     });
 
     it('can add another postprocessing instance', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = new PassPostProcess('pass', 1.0, null, undefined, engine);
 
@@ -50,8 +47,6 @@ describe('post-processing system', function () {
         .addComponent(PostProcess, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const component = cameraEntity.getMutableComponent(PostProcess)!;
       const pp2 = new PassPostProcess('pass2', 1.0, null, undefined, engine);
@@ -70,7 +65,7 @@ describe('post-processing system', function () {
     });
 
     it('can remove a postprocessing instance', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = new PassPostProcess('pass', 1.0, null, undefined, engine);
       const pp2 = new PassPostProcess('pass2', 1.0, null, undefined, engine);
@@ -82,8 +77,6 @@ describe('post-processing system', function () {
         .addComponent(PostProcess, { value: [pp, pp2] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const component = cameraEntity.getMutableComponent(PostProcess)!;
       component.value = [pp];
@@ -100,7 +93,7 @@ describe('post-processing system', function () {
     });
 
     it('can remove postprocessing instances', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = new PassPostProcess('pass', 1.0, null, undefined, engine);
 
@@ -111,8 +104,6 @@ describe('post-processing system', function () {
         .addComponent(PostProcess, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       cameraEntity.removeComponent(PostProcess);
       world.execute(0, 0);
@@ -124,7 +115,7 @@ describe('post-processing system', function () {
     });
 
     it('can remove the whole entity', function () {
-      const { world, rootEntity, engine } = setupWorld();
+      const { world, engine, scene } = setupWorld();
 
       const pp = new PassPostProcess('pass', 1.0, null, undefined, engine);
 
@@ -135,8 +126,6 @@ describe('post-processing system', function () {
         .addComponent(PostProcess, { value: [pp] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       cameraEntity.remove();
       world.execute(0, 0);
@@ -150,14 +139,12 @@ describe('post-processing system', function () {
   describe('builders', function () {
     describe('blur', function () {
       it('can add post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlurPostProcess);
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcesses).toHaveLength(1);
         const pp = scene.postProcesses[0] as BabylonBlurPostProcess;
@@ -170,7 +157,7 @@ describe('post-processing system', function () {
       });
 
       it('can add post-process with custom properties', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity
@@ -183,8 +170,6 @@ describe('post-processing system', function () {
           });
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcesses).toHaveLength(1);
         const pp = scene.postProcesses[0] as BabylonBlurPostProcess;
@@ -199,14 +184,13 @@ describe('post-processing system', function () {
       });
 
       it('can update post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlurPostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         const c = cameraEntity.getMutableComponent(BlurPostProcess);
         Object.assign(c, {
           name: 'test',
@@ -229,14 +213,13 @@ describe('post-processing system', function () {
       });
 
       it('can remove post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlurPostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.removeComponent(BlurPostProcess);
 
         world.execute(0, 0);
@@ -248,14 +231,13 @@ describe('post-processing system', function () {
       });
 
       it('can remove the whole entity', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlurPostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.remove();
 
         world.execute(0, 0);
@@ -267,14 +249,12 @@ describe('post-processing system', function () {
     });
     describe('black-and-white', function () {
       it('can add post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlackAndWhitePostProcess);
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcesses).toHaveLength(1);
         const pp = scene.postProcesses[0] as BabylonBlackAndWhitePostProcess;
@@ -286,7 +266,7 @@ describe('post-processing system', function () {
       });
 
       it('can add post-process with custom properties', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlackAndWhitePostProcess, {
@@ -294,8 +274,6 @@ describe('post-processing system', function () {
         });
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcesses).toHaveLength(1);
         const pp = scene.postProcesses[0] as BabylonBlackAndWhitePostProcess;
@@ -307,14 +285,13 @@ describe('post-processing system', function () {
       });
 
       it('can update post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlackAndWhitePostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         const c = cameraEntity.getMutableComponent(BlackAndWhitePostProcess);
         Object.assign(c, {
           name: 'test',
@@ -332,14 +309,13 @@ describe('post-processing system', function () {
       });
 
       it('can remove post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(BlackAndWhitePostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.removeComponent(BlackAndWhitePostProcess);
 
         world.execute(0, 0);
@@ -353,14 +329,12 @@ describe('post-processing system', function () {
     // Seems starting with babylon.js 4.2 we cannot test this with an NullEngine (having webGLVersion=1)
     describe.skip('motion-blur', function () {
       it('can add post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(MotionBlurPostProcess);
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcesses).toHaveLength(1);
         const pp = scene.postProcesses[0] as BabylonMotionBlurPostProcess;
@@ -374,7 +348,7 @@ describe('post-processing system', function () {
       });
 
       it('can add post-process with custom properties', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(MotionBlurPostProcess, {
@@ -384,8 +358,6 @@ describe('post-processing system', function () {
         });
 
         world.execute(0, 0);
-
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
 
         expect(scene.postProcesses).toHaveLength(1);
         const pp = scene.postProcesses[0] as BabylonMotionBlurPostProcess;
@@ -399,14 +371,13 @@ describe('post-processing system', function () {
       });
 
       it('can update post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(MotionBlurPostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         const c = cameraEntity.getMutableComponent(MotionBlurPostProcess);
         Object.assign(c, {
           name: 'test',
@@ -428,14 +399,13 @@ describe('post-processing system', function () {
       });
 
       it('can remove post-process', function () {
-        const { world, rootEntity } = setupWorld();
+        const { world, scene } = setupWorld();
 
         const cameraEntity = world.createEntity();
         cameraEntity.addComponent(Parent).addComponent(ArcRotateCamera).addComponent(MotionBlurPostProcess);
 
         world.execute(0, 0);
 
-        const { scene } = rootEntity.getComponent(BabylonCore)!;
         cameraEntity.removeComponent(MotionBlurPostProcess);
 
         world.execute(0, 0);

--- a/test/primitive.test.ts
+++ b/test/primitive.test.ts
@@ -1,4 +1,4 @@
-import { BabylonCore, Box, Lines, Parent, Plane, Sphere } from '../src/components';
+import { Box, Lines, Parent, Plane, Sphere } from '../src/components';
 import setupWorld from './helpers/setup-world';
 import { AbstractMesh } from '@babylonjs/core/Meshes/abstractMesh';
 import { Vector3 } from '@babylonjs/core/Maths/math.vector';
@@ -8,14 +8,12 @@ import { Color3 } from '@babylonjs/core/Maths/math.color';
 describe('primitive system', function () {
   describe('box', function () {
     it('can create a default box', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -30,14 +28,12 @@ describe('primitive system', function () {
     });
 
     it('can create a custom box', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box, { width: 2, height: 3, depth: 4 });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -52,14 +48,13 @@ describe('primitive system', function () {
     });
 
     it('can update a box', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box, { width: 2, height: 3, depth: 4 });
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Box);
       Object.assign(component, {
         width: 4,
@@ -78,14 +73,13 @@ describe('primitive system', function () {
     });
 
     it('can remove a box', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       entity.remove();
 
       world.execute(0, 0);
@@ -97,14 +91,12 @@ describe('primitive system', function () {
 
   describe('plane', function () {
     it('can create a default plane', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Plane);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -119,14 +111,12 @@ describe('primitive system', function () {
     });
 
     it('can create a custom plane', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Plane, { width: 2, height: 3 });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -141,14 +131,13 @@ describe('primitive system', function () {
     });
 
     it('can update a plane', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Plane, { width: 2, height: 3 });
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Plane);
       Object.assign(component, {
         width: 4,
@@ -166,14 +155,13 @@ describe('primitive system', function () {
     });
 
     it('can remove a plane', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Plane);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       entity.remove();
 
       world.execute(0, 0);
@@ -185,14 +173,12 @@ describe('primitive system', function () {
 
   describe('sphere', function () {
     it('can create a default sphere', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Sphere);
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -204,14 +190,12 @@ describe('primitive system', function () {
     });
 
     it('can create a custom sphere', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Sphere, { diameterX: 2, diameterY: 3, diameterZ: 4 });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -223,14 +207,13 @@ describe('primitive system', function () {
     });
 
     it('can update a sphere', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Sphere, { diameterX: 2, diameterY: 3, diameterZ: 4 });
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Sphere);
       Object.assign(component, {
         diameterX: 4,
@@ -249,14 +232,13 @@ describe('primitive system', function () {
     });
 
     it('can remove a sphere', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Sphere);
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       entity.remove();
 
       world.execute(0, 0);
@@ -268,7 +250,7 @@ describe('primitive system', function () {
 
   describe('lines', function () {
     it('can create a line', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -276,8 +258,6 @@ describe('primitive system', function () {
         .addComponent(Lines, { points: [new Vector3(-0.5, -0.5, 0), new Vector3(0.5, 0.5, 0)] });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
 
@@ -289,7 +269,7 @@ describe('primitive system', function () {
     });
 
     it('can apply color and alpha', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Lines, {
@@ -300,8 +280,6 @@ describe('primitive system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       expect(scene.meshes).toHaveLength(1);
 
       const mesh = scene.meshes[0] as LinesMesh;
@@ -311,7 +289,7 @@ describe('primitive system', function () {
     });
 
     it('can update a line', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Lines, {
@@ -322,7 +300,6 @@ describe('primitive system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Lines);
       Object.assign(component, {
         points: [new Vector3(-2, -1.5, 0), new Vector3(2, 1.5, 0)],
@@ -344,7 +321,7 @@ describe('primitive system', function () {
     });
 
     it('can remove a line', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -353,7 +330,6 @@ describe('primitive system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       entity.remove();
 
       world.execute(0, 0);

--- a/test/shadow.test.ts
+++ b/test/shadow.test.ts
@@ -1,10 +1,10 @@
-import { BabylonCore, Box, DirectionalLight, Parent, ShadowGenerator } from '../src/components';
+import { Box, DirectionalLight, Parent, ShadowGenerator } from '../src/components';
 import { DirectionalLight as BabylonDirectionalLight } from '@babylonjs/core/Lights/directionalLight';
 import setupWorld from './helpers/setup-world';
 
 describe('shadow system', function () {
   it('can add shadow generator', function () {
-    const { world, rootEntity } = setupWorld();
+    const { world, scene } = setupWorld();
 
     const lightEntity = world.createEntity();
     lightEntity.addComponent(Parent).addComponent(DirectionalLight).addComponent(ShadowGenerator);
@@ -13,8 +13,6 @@ describe('shadow system', function () {
     meshEntity.addComponent(Parent).addComponent(Box);
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.lights).toHaveLength(1);
 
@@ -29,7 +27,7 @@ describe('shadow system', function () {
   });
 
   it('can add shadow generator with custom arguments', function () {
-    const { world, rootEntity } = setupWorld();
+    const { world, scene } = setupWorld();
 
     const lightEntity = world.createEntity();
     lightEntity.addComponent(Parent).addComponent(DirectionalLight).addComponent(ShadowGenerator, {
@@ -41,8 +39,6 @@ describe('shadow system', function () {
     meshEntity.addComponent(Parent).addComponent(Box);
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     expect(scene.lights).toHaveLength(1);
 
@@ -56,7 +52,7 @@ describe('shadow system', function () {
   });
 
   it('can update shadow generator', function () {
-    const { world, rootEntity } = setupWorld();
+    const { world, scene } = setupWorld();
 
     const lightEntity = world.createEntity();
     lightEntity.addComponent(Parent).addComponent(DirectionalLight).addComponent(ShadowGenerator);
@@ -66,7 +62,6 @@ describe('shadow system', function () {
 
     world.execute(0, 0);
 
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
     const component = lightEntity.getMutableComponent(ShadowGenerator)!;
     component.size = 1024;
     component.forceBackFacesOnly = true;
@@ -83,7 +78,7 @@ describe('shadow system', function () {
   });
 
   it('can remove shadow generator', function () {
-    const { world, rootEntity } = setupWorld();
+    const { world, scene } = setupWorld();
 
     const lightEntity = world.createEntity();
     lightEntity.addComponent(Parent).addComponent(DirectionalLight).addComponent(ShadowGenerator);
@@ -92,8 +87,6 @@ describe('shadow system', function () {
     meshEntity.addComponent(Parent).addComponent(Box);
 
     world.execute(0, 0);
-
-    const { scene } = rootEntity.getComponent(BabylonCore)!;
 
     lightEntity.removeComponent(ShadowGenerator);
     world.execute(0, 0);

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,4 +1,4 @@
-import { BabylonCore, Box, Parent, Position, Rotation, Scale } from '../src/components';
+import { Box, Parent, Position, Rotation, Scale } from '../src/components';
 import { Vector3 } from '@babylonjs/core/Maths/math.vector';
 import setupWorld from './helpers/setup-world';
 import { PivotPoint } from '../src';
@@ -7,7 +7,7 @@ import { TransformNode } from '@babylonjs/core/Meshes/transformNode';
 describe('transform system', function () {
   describe('position', function () {
     it('can add position', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -17,22 +17,19 @@ describe('transform system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       expect(scene.meshes).toHaveLength(1);
       scene.meshes[0].computeWorldMatrix(true);
       expect(scene.meshes[0].getWorldMatrix().getTranslation().equalsToFloats(1, 2, 3)).toBeTrue();
     });
 
     it('can update position', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(Position, { value: Vector3.Zero() });
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Position)!;
       component.value = new Vector3(1, 2, 3);
 
@@ -44,7 +41,7 @@ describe('transform system', function () {
     });
 
     it('can remove position', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -53,8 +50,6 @@ describe('transform system', function () {
         .addComponent(Position, { value: new Vector3(1, 0, 1) });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       entity.removeComponent(Position);
       world.execute(0, 0);
@@ -66,7 +61,7 @@ describe('transform system', function () {
   });
   describe('rotation', function () {
     it('can add rotation', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -76,8 +71,6 @@ describe('transform system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       expect(scene.meshes).toHaveLength(1);
       scene.meshes[0].computeWorldMatrix(true);
       expect(scene.meshes[0].getWorldMatrix().getRotationMatrix().asArray()[0]).toBeCloseTo(-1);
@@ -86,14 +79,13 @@ describe('transform system', function () {
     });
 
     it('can update rotation', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(Rotation, { value: Vector3.Zero() });
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Rotation)!;
       component.value = new Vector3(0, Math.PI, 0);
 
@@ -107,7 +99,7 @@ describe('transform system', function () {
     });
 
     it('can remove rotation', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -116,8 +108,6 @@ describe('transform system', function () {
         .addComponent(Rotation, { value: new Vector3(1, 0, 1) });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       entity.removeComponent(Rotation);
       world.execute(0, 0);
@@ -131,7 +121,7 @@ describe('transform system', function () {
   });
   describe('scale', function () {
     it('can add scale', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -141,8 +131,6 @@ describe('transform system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       expect(scene.meshes).toHaveLength(1);
       scene.meshes[0].computeWorldMatrix(true);
       expect(scene.meshes[0].getWorldMatrix().asArray()[0]).toBeCloseTo(2);
@@ -151,14 +139,13 @@ describe('transform system', function () {
     });
 
     it('can update scale', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(Scale, { value: Vector3.One() });
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Scale)!;
       component.value = new Vector3(2, 1, 1);
 
@@ -172,7 +159,7 @@ describe('transform system', function () {
     });
 
     it('can remove scale', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -182,7 +169,6 @@ describe('transform system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       entity.removeComponent(Scale);
       world.execute(0, 0);
 
@@ -196,7 +182,7 @@ describe('transform system', function () {
   });
   describe('pivot point', function () {
     it('can add pivot point', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -206,20 +192,17 @@ describe('transform system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
-
       expect(scene.meshes).toHaveLength(1);
       expect((scene.meshes[0].parent as TransformNode).getAbsolutePivotPoint().equalsToFloats(1, 0, 0)).toBeTrue();
     });
 
     it('can update pivot point', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity.addComponent(Parent).addComponent(Box).addComponent(PivotPoint, { value: Vector3.Zero() });
 
       world.execute(0, 0);
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       expect(scene.meshes).toHaveLength(1);
       expect((scene.meshes[0].parent as TransformNode).getAbsolutePivotPoint().equalsToFloats(0, 0, 0)).toBeTrue();
@@ -233,7 +216,7 @@ describe('transform system', function () {
     });
 
     it('can remove pivot point', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       const entity = world.createEntity();
       entity
@@ -243,7 +226,6 @@ describe('transform system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       expect(scene.meshes).toHaveLength(1);
       expect((scene.meshes[0].parent as TransformNode).getAbsolutePivotPoint().equalsToFloats(1, 0, 0)).toBeTrue();
 

--- a/test/transition.test.ts
+++ b/test/transition.test.ts
@@ -1,6 +1,5 @@
 import {
   ArcRotateCamera,
-  BabylonCore,
   Box,
   DirectionalLight,
   Parent,
@@ -20,7 +19,7 @@ import { Color3 } from '@babylonjs/core/Maths/math.color';
 describe('transition system', function () {
   describe('general', function () {
     it('interpolates values over time', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -41,7 +40,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Position)!;
       component.value = new Vector3(1, 2, 3);
 
@@ -70,7 +68,7 @@ describe('transition system', function () {
     });
 
     it('uses transition multiple times', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -91,7 +89,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       let component = entity.getMutableComponent(Position)!;
       component.value = new Vector3(1, 2, 3);
 
@@ -142,7 +139,7 @@ describe('transition system', function () {
     });
 
     it('support multiple independent transitions', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -168,7 +165,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const position = entity.getMutableComponent(Position)!;
       position.value = new Vector3(1, 2, 3);
 
@@ -229,7 +225,7 @@ describe('transition system', function () {
     });
 
     it('support transitions on different Babylon instances', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -258,7 +254,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const position = entity.getMutableComponent(Position)!;
       position.value = new Vector3(1, 2, 3);
 
@@ -299,7 +294,7 @@ describe('transition system', function () {
     });
 
     it('changes without matching transition are applied immediately', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -321,7 +316,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const position = entity.getMutableComponent(Position)!;
       position.value = new Vector3(1, 2, 3);
       const scale = entity.getMutableComponent(Scale)!;
@@ -349,7 +343,7 @@ describe('transition system', function () {
     });
 
     it('duration of zero applies value immediately', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -370,7 +364,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Position)!;
       component.value = new Vector3(1, 2, 3);
 
@@ -384,7 +377,7 @@ describe('transition system', function () {
     });
 
     it('can update transition setting', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -405,7 +398,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const transitionComponent = entity.getMutableComponent(Transitions)!;
       transitionComponent.value[0] = {
         property: 'transform.position',
@@ -440,7 +432,7 @@ describe('transition system', function () {
     });
 
     it('can remove all transitions', function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -461,7 +453,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Position)!;
       component.value = new Vector3(1, 2, 3);
 
@@ -477,7 +468,7 @@ describe('transition system', function () {
     });
 
     it('can remove single transition', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -502,8 +493,6 @@ describe('transition system', function () {
         .addComponent(Scale, { value: Vector3.One() });
 
       world.execute(0, 0);
-
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
 
       const transitionComponent = entity.getMutableComponent(Transitions)!;
       transitionComponent.value = transitionComponent.value.slice(0, 1);
@@ -551,7 +540,7 @@ describe('transition system', function () {
 
   describe('transform', function () {
     it('can transition position', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -572,7 +561,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Position)!;
       component.value = new Vector3(1, 2, 3);
 
@@ -592,7 +580,7 @@ describe('transition system', function () {
     });
 
     it('can transition rotation', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -613,7 +601,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Rotation)!;
       component.value = new Vector3(0, Math.PI, 0);
 
@@ -633,7 +620,7 @@ describe('transition system', function () {
     });
 
     it('can transition scale', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -654,7 +641,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(Scale)!;
       component.value = new Vector3(2, 1, 1);
 
@@ -674,7 +660,7 @@ describe('transition system', function () {
   });
   describe('light', function () {
     it('can transition direction', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -694,7 +680,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(DirectionalLight)!;
       component.direction = new Vector3(1, 0, 0);
 
@@ -714,7 +699,7 @@ describe('transition system', function () {
     });
 
     it('can transition intensity', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -734,7 +719,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(DirectionalLight)!;
       component.intensity = 0;
 
@@ -752,7 +736,7 @@ describe('transition system', function () {
   });
   describe('material', function () {
     it('can transition color', async function () {
-      const { world, rootEntity } = setupWorld();
+      const { world, scene } = setupWorld();
 
       // we need a camera to trigger the render loop needed for animations
       world.createEntity().addComponent(Parent).addComponent(ArcRotateCamera);
@@ -775,7 +759,6 @@ describe('transition system', function () {
 
       world.execute(0, 0);
 
-      const { scene } = rootEntity.getComponent(BabylonCore)!;
       const component = entity.getMutableComponent(PbrMaterial)!;
       component.albedoColor = new Color3(0, 1, 0);
 


### PR DESCRIPTION
This fixes possible bugs when e.g. dealing with multiple `<canvas`> and thus scenes in a single browser session.